### PR TITLE
Fix travis CI setup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,10 @@
 language: python
+version: ~> 1.0
 python:
     - 2.7
     - 3.6
+os:
+    - linux
 cache:
     apt: true
     directories:
@@ -46,27 +49,27 @@ jobs:
           python: 2.7
           script: true
         - stage: checkout
-          name: checkout gcc riscv
+          name: checkout gcc riscv 2.7
           python: 2.7
           script:
               - ./dev_tools/ci/install_riscv_toolchain.sh 0
         - stage: compile
-          name: compile gcc riscv
+          name: compile gcc riscv 2.7
           python: 2.7
           script:
               - ./dev_tools/ci/install_riscv_toolchain.sh 1
         - stage: checkout
-          name: checkout gcc riscv
+          name: checkout gcc riscv 3.6
           python: 3.6
           script:
               - ./dev_tools/ci/install_riscv_toolchain.sh 0
         - stage: compile
-          name: compile gcc riscv
+          name: compile gcc riscv 3.6
           python: 3.6
           script:
               - ./dev_tools/ci/install_riscv_toolchain.sh 1
         - stage: conventions
-          name: shell conventions
+          name: shell conventions 2.7
           python: 2.7
           script: 
               - set -e

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,10 +37,10 @@ addons:
             - graphviz
             - shellcheck
 stages:
+    - shell_conventions
     - cache
     - checkout
     - compile
-    - conventions
     - tests
 jobs:
     include:
@@ -68,7 +68,7 @@ jobs:
           python: 3.6
           script:
               - ./dev_tools/ci/install_riscv_toolchain.sh 1
-        - stage: conventions
+        - stage: shell_conventions
           name: shell conventions 2.7
           python: 2.7
           script: 
@@ -83,14 +83,14 @@ script:
     # Code Conventions (always run)
     - ./dev_tools/ci/code_conventions_001_pycodestyle.sh
     - ./dev_tools/ci/code_conventions_002_pylint.sh
-    - if [ "$TRAVIS_PYTHON_VERSION" = "2.7" ]; then ./dev_tools/ci/code_conventions_003_documentation.sh; fi;
+    - ./dev_tools/ci/code_conventions_003_documentation.sh
     # Functional/Integration tests (always run)
     - MP_TESTING_ARCH=RISCV ./dev_tools/ci/test_001_end2end_tools.sh RISCV
     - MP_TESTING_ARCH=RISCV ./dev_tools/ci/test_002_end2end_examples.sh RISCV
     - MP_TESTING_ARCH=RISCV ./dev_tools/ci/test_003_end2end_targets.sh RISCV
     # Build Release (always run)
-    - if [ "$TRAVIS_PYTHON_VERSION" = "2.7" ]; then ./dev_tools/ci/build_001_distribution.sh ; fi;
+    - ./dev_tools/ci/build_001_distribution.sh
     # Test Release Deploy (always run)
-    - if [ "$TRAVIS_PYTHON_VERSION" = "2.7" ]; then ./dev_tools/ci/test_deploy_001_install.sh ${TRAVIS_PYTHON_VERSION} ; fi;
+    - ./dev_tools/ci/test_deploy_001_install.sh ${TRAVIS_PYTHON_VERSION}
 before_cache:
     - rm -fr $HOME/.cache/pip/log

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,4 @@
 language: python
-version: ~> 1.0
 python:
     - 2.7
     - 3.6

--- a/dev_tools/ci/install_riscv_toolchain.sh
+++ b/dev_tools/ci/install_riscv_toolchain.sh
@@ -38,13 +38,18 @@ if [ ! -d "$basedir/toolchain_riscv/install/bin" ]; then
 
     cd "$basedir/toolchain_riscv"
     if [ ! -f "$basedir/toolchain_riscv/riscv-gnu-toolchain/configure" ]; then
-        git clone --recursive https://github.com/riscv/riscv-gnu-toolchain -j "$MAXJOBS" --depth 1
+        # git clone --recursive https://github.com/riscv/riscv-gnu-toolchain -j "$MAXJOBS" --depth 1
+        git clone https://github.com/riscv/riscv-gnu-toolchain -j "$MAXJOBS" --depth 1
+        cd "$basedir/toolchain_riscv/riscv-gnu-toolchain"
+        for module in $(git submodule | sed "s/^ //" | cut -d ' ' -f 2 | grep -v qemu | grep -v gdb); do
+            git submodule update --init --recursive --progress --depth 1 -j "$MAXJOBS" "$module"
+        done;
     fi
 
     if [ ! -d "$basedir/toolchain_riscv/install/bin" ]; then
         if [ "$1" -ne "0" ] || [ -z "${1}" ]; then
             cd "$basedir/toolchain_riscv/riscv-gnu-toolchain"
-            ./configure --prefix="$basedir/toolchain_riscv/install/"
+            ./configure --prefix="$basedir/toolchain_riscv/install/" --disable-multilib --disable-gdb
             make -j "$MAXJOBS" > /dev/null 2> /dev/null &
             pid=$!
 


### PR DESCRIPTION
Travis CI has more strict job limits than the Travis enterprise version. That configuration miss-match lead to time-out CI failures in the public Travis CI runs that were undetected in IBM internal ones.  This commit fixes the issues by reducing the work done on the steps that were timing-out. In particular, now the risc-v custom toolchain is built without GDB and QEMU support.   

Signed-off-by: Ramon Bertran Monfort <rbertra@us.ibm.com>