### PR TITLE
Fix use of deprecated fractions.gcd function

### DIFF
--- a/targets/generic/wrappers/c.py
+++ b/targets/generic/wrappers/c.py
@@ -19,7 +19,7 @@ from __future__ import absolute_import, division
 
 # Built-in modules
 import itertools
-from fractions import gcd
+from math import gcd
 from time import localtime, strftime
 
 # Third party modules


### PR DESCRIPTION
This pull request removes the usage of `fractions.gcd` which was deprecated in Python 3.5 (released 2015, support ended 2017, security fixes end in September 2020) and removed in the latest versions of Python (particularly, my Python 3.9 installation doesn't have it).

The fix consists on using `math.gcd` instead, available since Python 3.5.