### PR TITLE
Allow for multiple opcode fields in same ISA

### DIFF
--- a/src/microprobe/target/isa/instruction.py
+++ b/src/microprobe/target/isa/instruction.py
@@ -1650,8 +1650,8 @@ class GenericInstructionType(InstructionType):
             )
         else:
             raise MicroprobeArchitectureDefinitionError(
-                "Instruction contains an inappropriate amount of opcode fields "
-                "(%d)" % opcode_operands.length)
+                    "Instruction contains an inappropriate amount of "
+                    "opcode fields (%d)" % opcode_operands.length)
 
     def _compute_mask(self):
 

--- a/src/microprobe/target/isa/instruction.py
+++ b/src/microprobe/target/isa/instruction.py
@@ -1642,10 +1642,16 @@ class GenericInstructionType(InstructionType):
                 operand, "I" in io_def, "O" in io_def
             )
 
-        if "opcode" in operands:
-            self.operands["opcode"][0] = OperandConst(
+        opcode_operands = [op for op in operands if op.startswith('opcode')]
+
+        if len(opcode_operands) == 1:
+            self.operands[opcode_operands[0]][0] = OperandConst(
                 "Opcode", "Instruction opcode", int(self.opcode, 16)
             )
+        else:
+            raise MicroprobeArchitectureDefinitionError(
+                "Instruction contains an inappropriate amount of opcode fields "
+                "(%d)" % opcode_operands.length)
 
     def _compute_mask(self):
 


### PR DESCRIPTION
This PR changes how the opcode is resolved when decoding an instruction.

Instead of checking that a particular field name matches the "opcode" string, now it looks for a field name which starts with such a string instead. This allows ISAs to specify multiple opcode fields, which is useful for when an ISA has multiple formats for an opcode (e.g. opcodes with different lengths like in RISC-V).