### PR TITLE
[RISCV] Implement C Extension

### DIFF
--- a/dev_tools/ci/environment.sh
+++ b/dev_tools/ci/environment.sh
@@ -84,9 +84,9 @@ else
     export BUILD_TYPE='stable'
 fi
 
-export MP_TESTING_CFLAGS_RISCV_V22="-march=rv64g"
+export MP_TESTING_CFLAGS_RISCV_V22="-march=rv64gc"
 export MP_TESTING_DFLAGS_RISCV_V22="-M numeric,no-aliases"
-export MP_TESTING_AFLAGS_RISCV_V22="-march=rv64g"
+export MP_TESTING_AFLAGS_RISCV_V22="-march=rv64gc"
 
 export PYTHONNOUSERSITE=True
 export PYTHONPATH=""

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -102,7 +102,7 @@ test5: ./source/examples_outputs/example_mp_c2mpt.mpt
 ./source/examples_outputs/example_mp_c2mpt.mpt: ../targets/riscv/tests/tools/c2mpt_test003.c ../targets/generic/tools/mp_c2mpt.py
 	rm -f ./source/examples_outputs/example_mp_c2mpt.mpt
 	mkdir -p ./source/examples_outputs/
-	mp_c2mpt.py -T riscv_v22-riscv_generic-riscv64_linux_gcc -P ../targets -i ../targets/riscv/tests/tools/c2mpt_test003.c -O ./source/examples_outputs/example_mp_c2mpt.mpt --target-c-compiler riscv64-unknown-elf-gcc --target-objdump riscv64-unknown-elf-objdump --target-c-compiler-flags="-O3 -march=rv64g"
+	mp_c2mpt.py -T riscv_v22-riscv_generic-riscv64_linux_gcc -P ../targets -i ../targets/riscv/tests/tools/c2mpt_test003.c -O ./source/examples_outputs/example_mp_c2mpt.mpt --target-c-compiler riscv64-unknown-elf-gcc --target-objdump riscv64-unknown-elf-objdump --target-c-compiler-flags="-O3 -march=rv64gc"
 
 subtests:
 	sh -c 'set -x; if [ $$(ls ../targets/*/doc/Makefile 2> /dev/null | wc -l) -gt 0 ] ; then for fmake in $$(ls ../targets/*/doc/Makefile | xargs -n1 dirname | sort | uniq) ; do $(MAKE) -j ${MAXJOBS} -C $$fmake tests; done; fi;'

--- a/src/microprobe/code/ins.py
+++ b/src/microprobe/code/ins.py
@@ -1614,6 +1614,8 @@ class Instruction(Pickable):
                             0], True, False, False, False))
                     operand_value.descriptor.set_type(operand_value.type)
 
+                    operand_value.set_value(operand_value.type.values()[0])
+
                     operand_values.append(operand_value)
 
             length_values = []

--- a/src/microprobe/target/isa/instruction.py
+++ b/src/microprobe/target/isa/instruction.py
@@ -1695,7 +1695,7 @@ class GenericInstructionType(InstructionType):
         mask = int(mask_str, 2)
 
         assert mask != 0
-        assert mask_val != 0
+        # assert mask_val != 0
 
         # print("{:032b}".format(mask), "{:032b}".format(mask_val), self.name)
 

--- a/src/microprobe/utils/asm.py
+++ b/src/microprobe/utils/asm.py
@@ -513,12 +513,22 @@ def _find_instr_with_mnemonic(mnemonic, asm_operands, target):
             riscv_fixes = [
                 (["s_imm5", "s_imm7"], "s_imm12"),
                 (["sb_imm5", "sb_imm7"], "sb_imm12"),
+                (["cd_imm3", "c_imm2"], "c_imm5"),
+                (["cw_imm3", "c_imm2"], "c_imm5"),
+                (['cb_imm5', 'c_imm3'], "c_imm8"),
+                (['cw_imm5', 'c_imm1'], "c_imm6"),
+                (['cd_imm5', 'c_imm1'], "c_imm6"),
+                (['ci_imm5', 'c_imm1'], "c_imm6"),
+                (['cu_imm5', 'c_imm1'], "c_imm6"),
+                (['cs_imm5', 'c_imm1'], "c_imm6"),
+                (['cls_imm5', 'c_imm1'], "c_imm6"),
             ]
 
             for fix in riscv_fixes:
                 if (all(field in fnames for field in fix[0])
                         and fix[1] in insfmt):
                     asm_operands.append("0x0")
+                    LOG.debug("Fixing in ASM")
                     return _find_instr_with_mnemonic(
                             mnemonic, asm_operands, target
                     )
@@ -693,6 +703,15 @@ def _sort_asm_operands_by_intr_type(asm_operands, instruction):
     riscv_fixes = [
         ("s_imm7", ["s_imm5"], "s_imm12"),
         ("sb_imm7", ["sb_imm5"], "sb_imm12"),
+        ("cd_imm3", ["c_imm2"], "c_imm5"),
+        ("cw_imm3", ["c_imm2"], "c_imm5"),
+        ('cb_imm5', ['c_imm3'], "c_imm8"),
+        ('cw_imm5', ['c_imm1'], "c_imm6"),
+        ('cd_imm5', ['c_imm1'], "c_imm6"),
+        ('ci_imm5', ['c_imm1'], "c_imm6"),
+        ('cu_imm5', ['c_imm1'], "c_imm6"),
+        ('cs_imm5', ['c_imm1'], "c_imm6"),
+        ('cls_imm5', ['c_imm1'], "c_imm6"),
     ]
 
     fix_found = False

--- a/src/microprobe/utils/bin.py
+++ b/src/microprobe/utils/bin.py
@@ -355,7 +355,7 @@ def _interpret_bin_instr(instr_type, bin_instr):
 
             def _parse_riscv_fix_field(fix):
                 value = 0
-                src_pos = 31
+                src_pos = (instr_type.format.length * 8) - 1
 
                 segments = fix[3].split(';')
                 for segment in segments:

--- a/src/microprobe/utils/bin.py
+++ b/src/microprobe/utils/bin.py
@@ -684,13 +684,6 @@ class MicroprobeBinInstructionStream(object):
                 "Unable to interpret the binary provided: %s" % bin_str
             )
 
-        if len(set([match[0].mnemonic for match in matches])) > 1:
-
-            raise MicroprobeBinaryError(
-                "Multiple possible instructions found. Candidates: %s" %
-                set([match[0].mnemonic for match in matches])
-            )
-
         if len(set([match[0].format.length for match in matches])) > 1:
             raise MicroprobeBinaryError(
                 "Multiple instructions with multiple lengths found"

--- a/targets/riscv/isa/riscv-common/instruction.py
+++ b/targets/riscv/isa/riscv-common/instruction.py
@@ -82,6 +82,23 @@ _5BITS_OPERAND_DESCRIPTOR = OperandDescriptor(
 # Functions
 
 
+def _n_bits_operand_descriptor(bits):
+    return OperandDescriptor(
+        OperandImmRange("dummy",  # Name
+                        "dummy",  # Description
+                        0,  # Min value
+                        (2 ** bits),  # Max value
+                        1,  # StepUImm1v0
+                        True,  # Address immediate
+                        0,  # Shift
+                        [],  # No values
+                        0  # Add
+                        ),
+        False,  # Input
+        False  # Output
+    )
+
+
 # Classes
 class RISCVInstruction(GenericInstructionType):
 
@@ -108,6 +125,11 @@ class RISCVInstruction(GenericInstructionType):
             args,
             dissabled_fields=['sb_imm7', 'sb_imm5',
                               's_imm7', 's_imm5',
+                              'c_imm1', 'c_imm2', 'c_imm3',
+                              'cw_imm3', 'cd_imm3',
+                              'cw_imm5', 'cd_imm5', 'cb_imm5', 'ci_imm5',
+                              'cu_imm5', 'cs_imm5', 'cls_imm5',
+                              'rs2_jr',
                               'pred', 'succ']
         )
 
@@ -129,9 +151,15 @@ class RISCVInstruction(GenericInstructionType):
                     (cfield, base))
 
         def _fix_field(string, base, dummy, field):
-            if string.find(base) > 0:
+            field_names = [field.name for field in self.format.fields]
+            if (string.find(base) > 0 and dummy in field_names
+                    and field in field_names):
                 assert _get_value(dummy, base) == "0"
                 value = _get_value(field, base)
+
+                if field == 'cu_imm5':
+                    value = str(int_to_twocs(int(value), 20))
+
                 return string.replace(base, str(value))
             else:
                 return string
@@ -142,6 +170,16 @@ class RISCVInstruction(GenericInstructionType):
         fix_fields = [
             ("sb_imm12", "sb_imm5", "sb_imm7"),
             ("s_imm12", "s_imm5", "s_imm7"),
+            ("c_imm6", "c_imm1", "c_imm5"),
+            ("c_imm5", "c_imm2", "cw_imm3"),
+            ("c_imm5", "c_imm2", "cd_imm3"),
+            ("c_imm8", "c_imm3", "cb_imm5"),
+            ("c_imm6", "c_imm1", "cw_imm5"),
+            ("c_imm6", "c_imm1", "cd_imm5"),
+            ("c_imm6", "c_imm1", "ci_imm5"),
+            ("c_imm6", "c_imm1", "cu_imm5"),
+            ("c_imm6", "c_imm1", "cs_imm5"),
+            ("c_imm6", "c_imm1", "cls_imm5")
         ]
 
         for fix in fix_fields:
@@ -181,18 +219,73 @@ class RISCVInstruction(GenericInstructionType):
         # codification bits
         # Operand Descriptor
         # Codification
+        # Signed?
         fixes = [
-            ('sb_imm7', 'sb_imm7', 13, _7BITS_OPERAND_DESCRIPTOR, '12|10:5'),
-            ('sb_imm5', 'sb_imm7', 13, _7BITS_OPERAND_DESCRIPTOR, '4:1|11'),
-            ('s_imm7', 's_imm7', 12, _7BITS_OPERAND_DESCRIPTOR, '11:5'),
-            ('s_imm5', 's_imm7', 12, _7BITS_OPERAND_DESCRIPTOR, '4:0'),
+            ('sb_imm7', 'sb_imm7', 13, _7BITS_OPERAND_DESCRIPTOR,
+                '12|10:5', True),
+            ('sb_imm5', 'sb_imm7', 13, _7BITS_OPERAND_DESCRIPTOR,
+                '4:1|11', True),
+            ('s_imm7', 's_imm7', 12, _7BITS_OPERAND_DESCRIPTOR,
+                '11:5', True),
+            ('s_imm5', 's_imm7', 12, _7BITS_OPERAND_DESCRIPTOR,
+                '4:0', True),
             ('uj_imm2', 'uj_imm20', 20, _20BITS_OPERAND_DESCRIPTOR,
-                '20|10:1|11|19:12'),
+                '20|10:1|11|19:12', True),
+            ('cw_imm3', 'cw_imm3', 7, _7BITS_OPERAND_DESCRIPTOR,
+                '5:3', False),
+            ('c_imm2', 'cw_imm3', 7, _7BITS_OPERAND_DESCRIPTOR,
+                '2|6', False),
+            ('cd_imm3', 'cd_imm3', 8, _n_bits_operand_descriptor(8),
+                '5:3', False),
+            ('c_imm2', 'cd_imm3', 8, _n_bits_operand_descriptor(8),
+                '7|6', False),
+            ('cb_imm5', 'cb_imm5', 9, _n_bits_operand_descriptor(9),
+                '7:6|2:1|5', True),
+            ('c_imm3', 'cb_imm5', 9, _n_bits_operand_descriptor(9),
+                '8|4:3', False),
+            ('cw_imm5', 'cw_imm5', 8, _n_bits_operand_descriptor(8),
+                '4:2|7:6', False),
+            ('c_imm1', 'cw_imm5', 8, _n_bits_operand_descriptor(8),
+                '5', False),
+            ('cd_imm5', 'cd_imm5', 9, _n_bits_operand_descriptor(9),
+                '4:3|8:6', False),
+            ('c_imm1', 'cd_imm5', 9, _n_bits_operand_descriptor(9),
+                '5', False),
+            ('ci_imm5', 'ci_imm5', 6, _n_bits_operand_descriptor(6),
+                '4:0', True),
+            ('c_imm1', 'ci_imm5', 6, _n_bits_operand_descriptor(6),
+                '5', True),
+            ('cu_imm5', 'cu_imm5', 20, _n_bits_operand_descriptor(20),
+                '4:0', False),
+            ('c_imm1', 'cu_imm5', 20, _n_bits_operand_descriptor(20),
+                '5', False),
+            ('cs_imm5', 'cs_imm5', 10, _n_bits_operand_descriptor(10),
+                '4|6|8:7|5', True),
+            ('c_imm1', 'cs_imm5', 10, _n_bits_operand_descriptor(10),
+                '9', False),
+            ('cls_imm5', 'cls_imm5', 6, _n_bits_operand_descriptor(6),
+                '4:0', False),
+            ('c_imm1', 'cls_imm5', 6, _n_bits_operand_descriptor(6),
+                '5', False),
+            ('cw_imm6', 'cw_imm6', 8, _n_bits_operand_descriptor(8),
+                '5:2|7:6', False),
+            ('cd_imm6', 'cd_imm6', 9, _n_bits_operand_descriptor(9),
+                '5:3|8:6', False),
+            ('c_imm11', 'c_imm11', 12, _n_bits_operand_descriptor(12),
+                '11|4|9:8|10|6|7|3:1|5', True),
+            ('cs_imm8', 'cs_imm8', 10, _n_bits_operand_descriptor(10),
+                '5:4|9:6|2|3', False),
+            ('crs1', 'crs1', 5, _n_bits_operand_descriptor(3), '2:0', False),
+            ('crs2', 'crs2', 5, _n_bits_operand_descriptor(3), '2:0', False),
+            ('crd', 'crd', 5, _n_bits_operand_descriptor(3), '2:0', False),
+            ('fcrs1', 'fcrs1', 5, _n_bits_operand_descriptor(3), '2:0', False),
+            ('fcrs2', 'fcrs2', 5, _n_bits_operand_descriptor(3), '2:0', False),
+            ('fcrd', 'fcrd', 5, _n_bits_operand_descriptor(3), '2:0', False),
         ]
 
         # Check if fixing is needed
         fix_needed = False
-        for (name, _, _, _, _) in fixes:
+        for (name, _, _, _, _, _) in fixes:
             if name in [field.name for field in self.format.fields]:
                 fix_needed = True
                 break
@@ -231,22 +324,28 @@ class RISCVInstruction(GenericInstructionType):
 
         fields = dict(zip([field.name for field in self.format.fields],
                       zip(self.format.fields, list(self.operands.items()))))
-        argdict = dict(zip([field.name for field in self.format.fields], args))
+        argdict = dict(zip([field.name for field in self.format.fields
+                            if field.default_show], args))
         fixed_args = dict()
 
         for fix in fixes:
-            if fix[0] in fields:
+            if fix[0] in fields and fix[1] in argdict:
                 field, op_descriptor = fields[fix[0]]
                 arg = argdict[fix[1]]
                 value = int(arg.type.codification(arg.value))
                 newarg = InstructionOperandValue(fix[3])
 
-                value_coded = int_to_twocs(value, fix[2])
-                assert twocs_to_int(value_coded, fix[2]) == value
+                if fix[5]:
+                    value_coded = int_to_twocs(value, fix[2])
+                    assert twocs_to_int(value_coded, fix[2]) == value
+                    value = value_coded
 
-                newarg.set_value(
-                    _code_fixed_field(value_coded << arg.type.shift, fix[4])
-                )
+                try:
+                    value <<= arg.type.shift
+                except AttributeError:  # Shifting not always will be available
+                    pass
+
+                newarg.set_value(_code_fixed_field(value, fix[4]))
                 fixed_args[fix[0]] = newarg
 
         newargs = []

--- a/targets/riscv/isa/riscv-common/instruction.py
+++ b/targets/riscv/isa/riscv-common/instruction.py
@@ -151,7 +151,7 @@ class RISCVInstruction(GenericInstructionType):
                     (cfield, base))
 
         def _fix_field(string, base, dummy, field):
-            field_names = [field.name for field in self.format.fields]
+            field_names = [fld.name for fld in self.format.fields]
             if (string.find(base) > 0 and dummy in field_names
                     and field in field_names):
                 assert _get_value(dummy, base) == "0"

--- a/targets/riscv/isa/riscv-common/instruction.yaml
+++ b/targets/riscv/isa/riscv-common/instruction.yaml
@@ -1956,6 +1956,7 @@
   Format: "ci_w"
   Operands:
     funct3: ['2', 'funct3', '?']
+    rd: ['nzreg', 'rd', 'O']
   ImplicitOperands:
     X2: ['X2', 'I']
   MemoryOperands:

--- a/targets/riscv/isa/riscv-common/instruction.yaml
+++ b/targets/riscv/isa/riscv-common/instruction.yaml
@@ -1748,3 +1748,279 @@
   Format: "i"
   Operands:
     funct3: ['4', 'funct3', '?']
+- Name: "C.ADDI4SPN_V0"
+  Mnemonic: "C.ADDI4SPN"
+  Opcode: "0"
+  Description: "Add azero-extended non-zero immediate, scaled by 4, to the stack pointer, x2, and write the result to rd'"
+  Format: "ciw"
+  Operands:
+    funct3: ['0', 'funct3', '?']
+- Name: "C.FLD_V0"
+  Mnemonic: "C.FLD"
+  Opcode: "0"
+  Format: "cl_d+f"
+  Operands:
+    funct3: ['1', 'funct3', '?']
+    crs1: ['crega', 'crs1', 'I']
+    cd_imm3: ['imm8_d', 'cd_imm3', 'I']
+  MemoryOperands:
+    MEM1 : [['cd_imm3', 'crs1'], [8], 8, 'I']
+- Name: "C.LW_V0"
+  Mnemonic: "C.LW"
+  Opcode: "0"
+  Format: "cl_w"
+  Operands:
+    funct3: ['2', 'funct3', '?']
+- Name: "C.LD_V0"
+  Mnemonic: "C.LD"
+  Opcode: "0"
+  Format: "cl_d"
+  Operands:
+    funct3: ['3', 'funct3', '?']
+    crs1: ['crega', 'crs1', 'I']
+    cd_imm3: ['imm8_d', 'cd_imm3', 'I']
+  MemoryOperands:
+    MEM1 : [['cd_imm3', 'crs1'], [8], 8, 'I']
+- Name: "C.FSD_V0"
+  Mnemonic: "C.FSD"
+  Opcode: "0"
+  Format: "cl_d+f"
+  Operands:
+    funct3: ['5', 'funct3', '?']
+    crs1: ['crega', 'crs1', 'I']
+  MemoryOperands:
+    MEM1 : [['cd_imm3', 'crs1'], [8], 8, 'O']
+- Name: "C.SW_V0"
+  Mnemonic: "C.SW"
+  Opcode: "0"
+  Format: "cl_w"
+  Operands:
+    funct3: ['6', 'funct3', '?']
+- Name: "C.SD_V0"
+  Mnemonic: "C.SD"
+  Opcode: "0"
+  Format: "cl_d"
+  Operands:
+    funct3: ['7', 'funct3', '?']
+- Name: "C.NOP_V0"
+  Mnemonic: "C.NOP"
+  Opcode: "1"
+  Format: "ci_u"
+  Operands:
+    funct3: ['0', 'funct3', '?']
+    c_imm1: ['0', 'c_imm1', '?']
+    rd: ['0', 'rd', 'IO']
+    cu_imm5: ['0', 'cu_imm5', '?']
+- Name: "C.ADDI_V0"
+  Mnemonic: "C.ADDI"
+  Opcode: "1"
+  Format: "ci_i"
+  Operands:
+    funct3: ['0', 'funct3', '?']
+    rd: ['nzreg', 'rd', 'IO']
+- Name: "C.ADDIW_V0"
+  Mnemonic: "C.ADDIW"
+  Opcode: "1"
+  Format: "ci_i"
+  Operands:
+    funct3: ['1', 'funct3', '?']
+    rd: ['nzreg', 'rd', 'IO']
+- Name: "C.LI_V0"
+  Mnemonic: "C.LI"
+  Opcode: "1"
+  Format: "ci_i"
+  Operands:
+    funct3: ['2', 'funct3', '?']
+    rd: ['nzreg', 'rd', 'IO']
+- Name: "C.ADDI16SP_V0"
+  Mnemonic: "C.ADDI16SP"
+  Opcode: "1"
+  Format: "ci_s"
+  Operands:
+    funct3: ['3', 'funct3', '?']
+    rd: ['spreg', 'rd', 'IO']
+- Name: "C.LUI_V0"
+  Mnemonic: "C.LUI"
+  Opcode: "1"
+  Format: "ci_u"
+  Operands:
+    funct3: ['3', 'funct3', '?']
+    rd: ['nzspreg', 'rd', 'IO']
+- Name: "C.SRLI_V0"
+  Mnemonic: "C.SRLI"
+  Opcode: "1"
+  Format: "cb_ls"
+  Operands:
+    funct3: ['4', 'funct3', '?']
+    funct2: ['0', 'funct2', '?']
+- Name: "C.SRAI_V0"
+  Mnemonic: "C.SRAI"
+  Opcode: "1"
+  Format: "cb_ls"
+  Operands:
+    funct3: ['4', 'funct3', '?']
+    funct2: ['1', 'funct2', '?']
+- Name: "C.ANDI_V0"
+  Mnemonic: "C.ANDI"
+  Opcode: "1"
+  Format: "cb_s"
+  Operands:
+    funct3: ['4', 'funct3', '?']
+    funct2: ['2', 'funct2', '?']
+- Name: "C.SUB_V0"
+  Mnemonic: "C.SUB"
+  Opcode: "1"
+  Format: "ca"
+  Operands:
+    funct6: ['35', 'funct6', '?']
+    funct2: ['0', 'funct2', '?']
+- Name: "C.XOR_V0"
+  Mnemonic: "C.XOR"
+  Opcode: "1"
+  Format: "ca"
+  Operands:
+    funct6: ['35', 'funct6', '?']
+    funct2: ['1', 'funct2', '?']
+- Name: "C.OR_V0"
+  Mnemonic: "C.OR"
+  Opcode: "1"
+  Format: "ca"
+  Operands:
+    funct6: ['35', 'funct6', '?']
+    funct2: ['2', 'funct2', '?']
+- Name: "C.AND_V0"
+  Mnemonic: "C.AND"
+  Opcode: "1"
+  Format: "ca"
+  Operands:
+    funct6: ['35', 'funct6', '?']
+    funct2: ['3', 'funct2', '?']
+- Name: "C.SUBW_V0"
+  Mnemonic: "C.SUBW"
+  Opcode: "1"
+  Format: "ca"
+  Operands:
+    funct6: ['39', 'funct6', '?']
+    funct2: ['0', 'funct2', '?']
+- Name: "C.ADDW_V0"
+  Mnemonic: "C.ADDW"
+  Opcode: "1"
+  Format: "ca"
+  Operands:
+    funct6: ['39', 'funct6', '?']
+    funct2: ['1', 'funct2', '?']
+- Name: "C.J_V0"
+  Mnemonic: "C.J"
+  Opcode: "1"
+  Format: "cj"
+  Operands:
+    funct3: ['5', 'funct3', '?']
+    #c_imm11: ['imm11', 'c_imm11', 'I']
+  MemoryOperands:
+    MEM1 : [['c_imm11'], [0], 0, 'B']
+- Name: "C.BEQZ_V0"
+  Mnemonic: "C.BEQZ"
+  Opcode: "1"
+  Format: "cb_b"
+  Operands:
+    funct3: ['6', 'funct3', '?']
+  MemoryOperands:
+    MEM1 : [['cb_imm5'], [0], 0, 'B']
+- Name: "C.BNEZ_V0"
+  Mnemonic: "C.BNEZ"
+  Opcode: "1"
+  Format: "cb_b"
+  Operands:
+    funct3: ['7', 'funct3', '?']
+  MemoryOperands:
+    MEM1 : [['cb_imm5'], [0], 0, 'B']
+- Name: "C.SLLI_V0"
+  Mnemonic: "C.SLLI"
+  Opcode: "2"
+  Format: "ci_ls"
+  Operands:
+    funct3: ['0', 'funct3', '?']
+- Name: "C.FLDSP_V0"
+  Mnemonic: "C.FLDSP"
+  Opcode: "2"
+  Format: "ci_d+f"
+  Operands:
+    funct3: ['1', 'funct3', '?']
+- Name: "C.LWSP_V0"
+  Mnemonic: "C.LWSP"
+  Opcode: "2"
+  Format: "ci_w"
+  Operands:
+    funct3: ['2', 'funct3', '?']
+- Name: "C.LDSP_V0"
+  Mnemonic: "C.LDSP"
+  Opcode: "2"
+  Format: "ci_d"
+  Operands:
+    funct3: ['3', 'funct3', '?']
+    rd: ['nzreg', 'rd', 'O']
+  ImplicitOperands:
+    X2: ['X2', 'I']
+  MemoryOperands:
+    MEM1 : [['X2', 'cd_imm5'], [8], 8, 'I']
+- Name: "C.JR_V0"
+  Mnemonic: "C.JR"
+  Opcode: "2"
+  Format: "cr_jr"
+  Operands:
+    funct4: ['8', 'funct4', '?']
+    rd: ['nzreg', 'rd', 'I']
+  MemoryOperands:
+    MEM1 : [['rd'], [0], 0, 'B']
+- Name: "C.MV_V0"
+  Mnemonic: "C.MV"
+  Opcode: "2"
+  Format: "cr"
+  Operands:
+    funct4: ['8', 'funct4', '?']
+    rd: ['nzreg', 'rd', 'IO']
+    rs2: ['nzreg', 'rs2', 'IO']
+- Name: "C.EBREAK_V0"
+  Mnemonic: "C.EBREAK"
+  Opcode: "2"
+  Format: "cr"
+  Operands:
+    funct4: ['9', 'funct4', '?']
+    rd: ['X0', 'rd', 'IO']
+    rs2: ['X0', 'rs2', 'IO']
+- Name: "C.JALR_V0"
+  Mnemonic: "C.JALR"
+  Opcode: "2"
+  Format: "cr"
+  Operands:
+    funct4: ['9', 'funct4', '?']
+    rd: ['nzreg', 'rd', 'IO']
+    rs2: ['X0', 'rs2', 'IO']
+  MemoryOperands:
+    MEM1 : [['rd'], [0], 0, 'B']
+- Name: "C.ADD_V0"
+  Mnemonic: "C.ADD"
+  Opcode: "2"
+  Format: "cr"
+  Operands:
+    funct4: ['9', 'funct4', '?']
+    rd: ['nzreg', 'rd', 'IO']
+    rs2: ['nzreg', 'rs2', 'IO']
+- Name: "C.FSDSP_V0"
+  Mnemonic: "C.FSDSP"
+  Opcode: "2"
+  Format: "css_d+f"
+  Operands:
+    funct3: ['5', 'funct3', '?']
+- Name: "C.SWSP_V0"
+  Mnemonic: "C.SWSP"
+  Opcode: "2"
+  Format: "css_w"
+  Operands:
+    funct3: ['6', 'funct3', '?']
+- Name: "C.SDSP_V0"
+  Mnemonic: "C.SDSP"
+  Opcode: "2"
+  Format: "css_d"
+  Operands:
+    funct3: ['7', 'funct3', '?']

--- a/targets/riscv/isa/riscv-common/instruction.yaml
+++ b/targets/riscv/isa/riscv-common/instruction.yaml
@@ -1807,12 +1807,10 @@
 - Name: "C.NOP_V0"
   Mnemonic: "C.NOP"
   Opcode: "1"
-  Format: "ci_u"
+  Format: "c_funct14"
   Operands:
-    funct3: ['0', 'funct3', '?']
-    c_imm1: ['0', 'c_imm1', '?']
-    rd: ['0', 'rd', 'IO']
-    cu_imm5: ['0', 'cu_imm5', '?']
+    funct4: ['0', 'funct4', '?']
+    funct10: ['0', 'funct10', '?']
 - Name: "C.ADDI_V0"
   Mnemonic: "C.ADDI"
   Opcode: "1"
@@ -1993,19 +1991,19 @@
 - Name: "C.EBREAK_V0"
   Mnemonic: "C.EBREAK"
   Opcode: "2"
-  Format: "cr"
+  Format: "c_funct14"
   Operands:
     funct4: ['9', 'funct4', '?']
-    rd: ['X0', 'rd', 'IO']
-    rs2: ['X0', 'rs2', 'IO']
+    funct10: ['0', 'funct10', '?']
 - Name: "C.JALR_V0"
   Mnemonic: "C.JALR"
   Opcode: "2"
-  Format: "cr"
+  Format: "cr_jr"
   Operands:
     funct4: ['9', 'funct4', '?']
     rd: ['nzreg', 'rd', 'IO']
-    rs2: ['X0', 'rs2', 'IO']
+  ImplicitOperands:
+    X1: ['X1', 'O']
   MemoryOperands:
     MEM1 : [['rd'], [0], 0, 'B']
 - Name: "C.ADD_V0"

--- a/targets/riscv/isa/riscv-common/instruction.yaml
+++ b/targets/riscv/isa/riscv-common/instruction.yaml
@@ -1796,6 +1796,8 @@
   Format: "cl_w"
   Operands:
     funct3: ['6', 'funct3', '?']
+  MemoryOperands:
+    MEM1 : [['cw_imm3', 'crs1'], [8], 8, 'O']
 - Name: "C.SD_V0"
   Mnemonic: "C.SD"
   Opcode: "0"
@@ -1946,12 +1948,20 @@
   Format: "ci_d+f"
   Operands:
     funct3: ['1', 'funct3', '?']
+  ImplicitOperands:
+    X2: ['X2', 'I']
+  MemoryOperands:
+    MEM1 : [['X2', 'cd_imm5'], [8], 8, 'I']
 - Name: "C.LWSP_V0"
   Mnemonic: "C.LWSP"
   Opcode: "2"
   Format: "ci_w"
   Operands:
     funct3: ['2', 'funct3', '?']
+  ImplicitOperands:
+    X2: ['X2', 'I']
+  MemoryOperands:
+    MEM1 : [['X2', 'cw_imm5'], [4], 4, 'I']
 - Name: "C.LDSP_V0"
   Mnemonic: "C.LDSP"
   Opcode: "2"
@@ -2012,15 +2022,27 @@
   Format: "css_d+f"
   Operands:
     funct3: ['5', 'funct3', '?']
+  ImplicitOperands:
+    X2: ['X2', 'I']
+  MemoryOperands:
+    MEM1 : [['X2', 'cd_imm6'], [8], 8, 'O']
 - Name: "C.SWSP_V0"
   Mnemonic: "C.SWSP"
   Opcode: "2"
   Format: "css_w"
   Operands:
     funct3: ['6', 'funct3', '?']
+  ImplicitOperands:
+    X2: ['X2', 'I']
+  MemoryOperands:
+    MEM1 : [['X2', 'cw_imm6'], [4], 4, 'O']
 - Name: "C.SDSP_V0"
   Mnemonic: "C.SDSP"
   Opcode: "2"
   Format: "css_d"
   Operands:
     funct3: ['7', 'funct3', '?']
+  ImplicitOperands:
+    X2: ['X2', 'I']
+  MemoryOperands:
+    MEM1 : [['X2', 'cd_imm6'], [8], 8, 'O']

--- a/targets/riscv/isa/riscv-common/instruction_field.yaml
+++ b/targets/riscv/isa/riscv-common/instruction_field.yaml
@@ -77,6 +77,12 @@
   Show: True
   IO: "I"
   Operand: "imm7"
+- Name: "funct10"
+  Size: 10
+  Description: "funct10"
+  Show: False
+  IO: "I"
+  Operand: "imm10"
 - Name: "i_imm12"
   Size: 12
   Description: "i_imm12"
@@ -404,7 +410,7 @@
   Description: "c_imm5 (dummy)"
   Show: True
   IO: "I"
-  Operand: "u.imm6"
+  Operand: "nz_u.imm6"
 - Name: "cu_imm5"
   Size: 5
   Description: "c_imm5 (dummy)"
@@ -416,7 +422,7 @@
   Description: "c_imm5 (dummy)"
   Show: True
   IO: "I"
-  Operand: "imm10"
+  Operand: "nz_imm10"
 - Name: "cb_imm5"
   Size: 5
   Description: "c_imm5 (dummy)"
@@ -446,7 +452,7 @@
   Description: "cs_imm8"
   Show: True
   IO: "I"
-  Operand: "imm8"
+  Operand: "nz_imm8"
 - Name: "c_imm11"
   Size: 11
   Description: "c_imm11"

--- a/targets/riscv/isa/riscv-common/instruction_field.yaml
+++ b/targets/riscv/isa/riscv-common/instruction_field.yaml
@@ -53,12 +53,24 @@
   Show: False
   IO: "?"
   Operand: "imm3"
+- Name: "funct4"
+  Size: 4
+  Description: "funct4"
+  Show: False
+  IO: "?"
+  Operand: "imm4"
 - Name: "funct5"
   Size: 5
   Description: "funct5"
   Show: False
   IO: "?"
   Operand: "imm5"
+- Name: "funct6"
+  Size: 6
+  Description: "funct6"
+  Show: False
+  IO: "?"
+  Operand: "imm6"
 - Name: "funct7"
   Size: 7
   Description: "funct7"
@@ -213,6 +225,12 @@
   Show: True
   IO: "I"
   Operand: "reg"
+- Name: "rs2_jr"
+  Size: 5
+  Description: "rs2 (disabled)"
+  Show: True
+  IO: "I"
+  Operand: "X0"
 - Name: "rs2c"
   Size: 5
   Description: "rs2"
@@ -284,3 +302,166 @@
   Show: True
   IO: "I"
   Operand: "s.imm20"
+- Name: "opcode_compressed"
+  Size: 2
+  Description: "opcode (compressed)"
+  Show: False
+  IO: "?"
+  Operand: "imm2"
+- Name: "crd"
+  Size: 3
+  Description: "rd (compressed)"
+  Show: True
+  IO: "O"
+  Operand: "creg"
+- Name: "crs1"
+  Size: 3
+  Description: "rs1 (compressed)"
+  Show: True
+  IO: "I"
+  Operand: "creg"
+- Name: "crs2"
+  Size: 3
+  Description: "rs2 (compressed)"
+  Show: True
+  IO: "I"
+  Operand: "creg"
+- Name: "fcrd"
+  Size: 3
+  Description: "rd (compressed)"
+  Show: True
+  IO: "O"
+  Operand: "fcreg"
+- Name: "fcrs1"
+  Size: 3
+  Description: "rs1 (compressed)"
+  Show: True
+  IO: "I"
+  Operand: "fcreg"
+- Name: "fcrs2"
+  Size: 3
+  Description: "rs2 (compressed)"
+  Show: True
+  IO: "I"
+  Operand: "fcreg"
+- Name: "c_imm1"
+  Size: 1
+  Description: "c_imm1 (dummy)"
+  Show: True
+  IO: "I"
+  Operand: "Zero"
+- Name: "c_imm2"
+  Size: 2
+  Description: "c_imm2 (dummy)"
+  Show: True
+  IO: "I"
+  Operand: "Zero"
+- Name: "c_imm3"
+  Size: 3
+  Description: "c_imm3 (dummy)"
+  Show: True
+  IO: "I"
+  #Operand: "imm3"
+  Operand: "Zero"
+- Name: "cw_imm3"
+  Size: 3
+  Description: "c_imm3 (dummy)"
+  Show: True
+  IO: "I"
+  Operand: "imm7_w"
+- Name: "cd_imm3"
+  Size: 3
+  Description: "c_imm3 (dummy)"
+  Show: True
+  IO: "I"
+  Operand: "imm8_d"
+- Name: "c_imm5"
+  Size: 5
+  Description: "c_imm5 (dummy)"
+  Show: False
+  IO: "I"
+  Operand: "imm5"
+- Name: "cw_imm5"
+  Size: 5
+  Description: "c_imm5 (dummy)"
+  Show: True
+  IO: "I"
+  Operand: "imm8_w"
+- Name: "cd_imm5"
+  Size: 5
+  Description: "c_imm5 (dummy)"
+  Show: True
+  IO: "I"
+  Operand: "imm9_d"
+- Name: "ci_imm5"
+  Size: 5
+  Description: "c_imm5 (dummy)"
+  Show: True
+  IO: "I"
+  Operand: "simm6"
+- Name: "cls_imm5"
+  Size: 5
+  Description: "c_imm5 (dummy)"
+  Show: True
+  IO: "I"
+  Operand: "u.imm6"
+- Name: "cu_imm5"
+  Size: 5
+  Description: "c_imm5 (dummy)"
+  Show: True
+  IO: "I"
+  Operand: "imm20_clui"
+- Name: "cs_imm5"
+  Size: 5
+  Description: "c_imm5 (dummy)"
+  Show: True
+  IO: "I"
+  Operand: "imm10"
+- Name: "cb_imm5"
+  Size: 5
+  Description: "c_imm5 (dummy)"
+  Show: True
+  IO: "I"
+  Operand: "sbimm9"
+- Name: "c_imm6"
+  Size: 6
+  Description: "c_imm6"
+  Show: True
+  IO: "I"
+  Operand: "imm6"
+- Name: "cw_imm6"
+  Size: 6
+  Description: "c_imm6"
+  Show: True
+  IO: "I"
+  Operand: "imm8_w"
+- Name: "cd_imm6"
+  Size: 6
+  Description: "cd_imm6"
+  Show: True
+  IO: "I"
+  Operand: "imm9_d"
+- Name: "cs_imm8"
+  Size: 8
+  Description: "cs_imm8"
+  Show: True
+  IO: "I"
+  Operand: "imm8"
+- Name: "c_imm11"
+  Size: 11
+  Description: "c_imm11"
+  Show: True
+  IO: "I"
+  Operand: "imm11"
+- Name: "nzspreg"
+  Size: 5
+  Description: "Non-Zero and Non-Stack-Pointer register"
+  Show: True
+  IO: "I"
+  Operand: "nzspreg"
+- Name: "spreg"
+  Size: 5
+  Description: "Stack Pointer Register"
+  Show: True
+  IO: "I"
+  Operand: "spreg"

--- a/targets/riscv/isa/riscv-common/instruction_format.yaml
+++ b/targets/riscv/isa/riscv-common/instruction_format.yaml
@@ -410,6 +410,12 @@
   - rs2_jr
   - opcode_compressed
   Assembly: OPC rd
+- Name: "c_funct14"
+  Fields:
+  - funct4
+  - funct10
+  - opcode_compressed
+  Assembly: OPC
 - Name: "ci_w"
   Fields:
   - funct3

--- a/targets/riscv/isa/riscv-common/instruction_format.yaml
+++ b/targets/riscv/isa/riscv-common/instruction_format.yaml
@@ -396,3 +396,194 @@
   - rd
   - opcode
   Assembly: OPC rd, uj_imm20
+- Name: "cr"
+  Fields:
+  - funct4
+  - rd
+  - rs2
+  - opcode_compressed
+  Assembly: OPC rd, rs2
+- Name: "cr_jr"
+  Fields:
+  - funct4
+  - rd
+  - rs2_jr
+  - opcode_compressed
+  Assembly: OPC rd
+- Name: "ci_w"
+  Fields:
+  - funct3
+  - c_imm1
+  - rd
+  - cw_imm5
+  - opcode_compressed
+  Assembly: OPC rd, c_imm6(sp)
+- Name: "ci_i"
+  Fields:
+  - funct3
+  - c_imm1
+  - rd
+  - ci_imm5
+  - opcode_compressed
+  Assembly: OPC rd, c_imm6
+- Name: "ci_ls"
+  Fields:
+  - funct3
+  - c_imm1
+  - rd
+  - cls_imm5
+  - opcode_compressed
+  Assembly: OPC rd, c_imm6
+- Name: "ci_d"
+  Fields:
+  - funct3
+  - c_imm1
+  - rd
+  - cd_imm5
+  - opcode_compressed
+  Assembly: OPC rd, c_imm6(sp)
+- Name: "ci_d+f"
+  Fields:
+  - funct3
+  - c_imm1
+  - frd
+  - cd_imm5
+  - opcode_compressed
+  Assembly: OPC frd, c_imm6(sp)
+- Name: "ci_u"
+  Fields:
+  - funct3
+  - c_imm1
+  - rd
+  - cu_imm5
+  - opcode_compressed
+  Assembly: OPC rd, c_imm6
+- Name: "ci_s"
+  Fields:
+  - funct3
+  - c_imm1
+  - rd
+  - cs_imm5
+  - opcode_compressed
+  Assembly: OPC rd, c_imm6
+- Name: "css_w"
+  Fields:
+  - funct3
+  - cw_imm6
+  - rs2
+  - opcode_compressed
+  Assembly: OPC rs2, cw_imm6(sp)
+- Name: "css_d"
+  Fields:
+  - funct3
+  - cd_imm6
+  - rs2
+  - opcode_compressed
+  Assembly: OPC rs2, cd_imm6(sp)
+- Name: "css_d+f"
+  Fields:
+  - funct3
+  - cd_imm6
+  - frs2
+  - opcode_compressed
+  Assembly: OPC frs2, cd_imm6(sp)
+- Name: "ciw"
+  Fields:
+  - funct3
+  - cs_imm8
+  - crd
+  - opcode_compressed
+  Assembly: OPC crd, sp, cs_imm8
+- Name: "cl_w"
+  Fields:
+  - funct3
+  - cw_imm3
+  - crs1
+  - c_imm2
+  - crd
+  - opcode_compressed
+  Assembly: OPC crd, c_imm5(crs1)
+- Name: "cl_d"
+  Fields:
+  - funct3
+  - cd_imm3
+  - crs1
+  - c_imm2
+  - crd
+  - opcode_compressed
+  Assembly: OPC crd, c_imm5(crs1)
+- Name: "cl_d+f"
+  Fields:
+  - funct3
+  - cd_imm3
+  - crs1
+  - c_imm2
+  - fcrd
+  - opcode_compressed
+  Assembly: OPC fcrd, c_imm5(crs1)
+- Name: "cs_w"
+  Fields:
+  - funct3
+  - cw_imm3
+  - crs1
+  - c_imm2
+  - crs2
+  - opcode_compressed
+  Assembly: OPC crs2, c_imm5(crs1)
+- Name: "cs_d"
+  Fields:
+  - funct3
+  - cd_imm3
+  - crs1
+  - c_imm2
+  - crs2
+  - opcode_compressed
+  Assembly: OPC crs2, c_imm5(crs1)
+- Name: "ca"
+  Fields:
+  - funct6
+  - crd
+  - funct2
+  - crs2
+  - opcode_compressed
+  Assembly: OPC crd, crs2
+- Name: "cb_b"
+  Fields:
+  - funct3
+  - c_imm3
+  - crs1
+  - cb_imm5
+  - opcode_compressed
+  Assembly: OPC crs1, c_imm8
+- Name: "cb_i"
+  Fields:
+  - funct3
+  - c_imm3
+  - crs1
+  - ci_imm5
+  - opcode_compressed
+  Assembly: OPC crs1, c_imm8(crs1)
+- Name: "cb_s"
+  Fields:
+  - funct3
+  - c_imm1
+  - funct2
+  - crd
+  - ci_imm5
+  - opcode_compressed
+  Assembly: OPC crd, c_imm6
+- Name: "cb_ls"
+  Fields:
+  - funct3
+  - c_imm1
+  - funct2
+  - crd
+  - cls_imm5
+  - opcode_compressed
+  Assembly: OPC crd, c_imm6
+- Name: "cj"
+  Fields:
+  - funct3
+  - c_imm11
+  - opcode_compressed
+  Assembly: OPC c_imm11

--- a/targets/riscv/isa/riscv-common/instruction_props/branch.yaml
+++ b/targets/riscv/isa/riscv-common/instruction_props/branch.yaml
@@ -24,3 +24,9 @@
     BNE_V0: True
     JALR_V0: True
     JAL_V0: True
+    C.J_V0: True
+    C.JAL_V0: True
+    C.JR_V0: True
+    C.JALR_V0: True
+    C.BEQZ_V0: True
+    C.BNEZ_V0: True

--- a/targets/riscv/isa/riscv-common/instruction_props/branch_conditional.yaml
+++ b/targets/riscv/isa/riscv-common/instruction_props/branch_conditional.yaml
@@ -22,3 +22,5 @@
     BLTU_V0: True
     BLT_V0: True
     BNE_V0: True
+    C.BEQZ_V0: True
+    C.BNEZ_V0: True

--- a/targets/riscv/isa/riscv-common/instruction_props/branch_relative.yaml
+++ b/targets/riscv/isa/riscv-common/instruction_props/branch_relative.yaml
@@ -23,3 +23,7 @@
     BLT_V0: True
     BNE_V0: True
     JAL_V0: True
+    C.J_V0: True
+    C.JAL_V0: True
+    C.BEQZ_V0: True
+    C.BNEZ_V0: True

--- a/targets/riscv/isa/riscv-common/instruction_props/memory.yaml
+++ b/targets/riscv/isa/riscv-common/instruction_props/memory.yaml
@@ -61,3 +61,20 @@
     SD_V0: True
     SH_V0: True
     SW_V0: True
+    C.LW_V0: True
+    C.SW_V0: True
+    C.LD_V0: True
+    C.SD_V0: True
+    C.FLD_V0: True
+    C.FSD_V0: True
+    C.LWSP_V0: True
+    C.SWSP_V0: True
+    C.LDSP_V0: True
+    C.FSDSP_V0: True
+    C.SDSP_V0: True
+    C.J_V0: True
+    C.JAL_V0: True
+    C.JR_V0: True
+    C.JALR_V0: True
+    C.BEQZ_V0: True
+    C.BNEZ_V0: True

--- a/targets/riscv/isa/riscv-common/isa.py
+++ b/targets/riscv/isa/riscv-common/isa.py
@@ -632,7 +632,7 @@ class RISCVISA(GenericISA):
                     value += 1
                 new_operands.append(str(value))
             return mnemonic, new_operands
-        elif mnemonic == "C.JR":
+        elif mnemonic == "C.JR" or mnemonic == "C.JALR":
             operands.append('X0')
             return mnemonic, operands
         else:

--- a/targets/riscv/isa/riscv-common/isa.py
+++ b/targets/riscv/isa/riscv-common/isa.py
@@ -632,8 +632,14 @@ class RISCVISA(GenericISA):
                     value += 1
                 new_operands.append(str(value))
             return mnemonic, new_operands
+        elif mnemonic == "C.JR":
+            operands.append('X0')
+            return mnemonic, operands
+        else:
+            # Remove the implicit stack pointer operand from all instructions
+            new_operands = [op for op in operands if op != "SP"]
 
-        return mnemonic, operands
+            return mnemonic, new_operands
 
     def randomize_register(self, register, seed=None):
 

--- a/targets/riscv/isa/riscv-common/operand.yaml
+++ b/targets/riscv/isa/riscv-common/operand.yaml
@@ -94,10 +94,71 @@
   Description: 5-bit immediate
   Min: 0
   Max: 31
+- Name: simm5
+  Description: 5-bit immediate (signed)
+  Min: -16
+  Max: 15
+- Name: simm6
+  Description: 6-bit immediate (signed)
+  Min: -32
+  Max: 31
+- Name: imm6
+  Description: 6-bit immediate
+  Min: 0
+  Max: 63
 - Name: imm7
   Description: 7-bit immediate
   Min: 0
   Max: 127
+- Name: imm7_w
+  Description: 7-bit immediate (Word Stepping)
+  Min: 0
+  Max: 127
+  Step: 4
+- Name: imm8
+  Description: 8-bit immediate
+  Min: 0
+  Max: 1023
+  Step: 4
+- Name: imm8_d
+  Description: 8-bit immediate (Double Stepping)
+  Min: 0
+  Max: 255
+  Step: 8
+  AddressIndex: True
+- Name: imm8_w
+  Description: 8-bit immediate (Word Stepping)
+  Min: 0
+  Max: 255
+  Step: 4
+- Name: imm9_d
+  Description: 9-bit immediate (Double Stepping)
+  Min: 0
+  Max: 511
+  Step: 8
+  AddressIndex: True
+- Name: imm11
+  Description: 11-bit immediate
+  MinDisplacement: -2048
+  MaxDisplacement: 2047
+  Relative: True
+  Step: 2
+- Name: imm18
+  Description: 11-bit immediate
+  Min: -32
+  Max: 31
+  Shift: 12
+- Name: imm10
+  Description: 10-bit immediate
+  Min: -512
+  Max: 511
+  Step: 16
+- Name: sbimm9
+  Description: 9-bit signed immediate
+  MinDisplacement: -256
+  MaxDisplacement: 255
+  Step: 2
+  Relative: True
 - Name: jimm20
   Description: 20-bit immediate
   Min: 0
@@ -256,3 +317,181 @@
   - 'rdn'
   - 'rup'
   - 'rmm'
+- Name: nzreg
+  Description: Non-zero Integer Registers
+  Registers:
+    X1 : ['X1']
+    X2 : ['X2']
+    X3 : ['X3']
+    X4 : ['X4']
+    X5 : ['X5']
+    X6 : ['X6']
+    X7 : ['X7']
+    X8 : ['X8']
+    X9 : ['X9']
+    X10 : ['X10']
+    X11 : ['X11']
+    X12 : ['X12']
+    X13 : ['X13']
+    X14 : ['X14']
+    X15 : ['X15']
+    X16 : ['X16']
+    X17 : ['X17']
+    X18 : ['X18']
+    X19 : ['X19']
+    X20 : ['X20']
+    X21 : ['X21']
+    X22 : ['X22']
+    X23 : ['X23']
+    X24 : ['X24']
+    X25 : ['X25']
+    X26 : ['X26']
+    X27 : ['X27']
+    X28 : ['X28']
+    X29 : ['X29']
+    X30 : ['X30']
+    X31 : ['X31']
+- Name: nzspreg
+  Description: Non-zero Non-stack-pointer Integer Registers
+  Registers:
+    X1 : ['X1']
+    X3 : ['X3']
+    X4 : ['X4']
+    X5 : ['X5']
+    X6 : ['X6']
+    X7 : ['X7']
+    X8 : ['X8']
+    X9 : ['X9']
+    X10 : ['X10']
+    X11 : ['X11']
+    X12 : ['X12']
+    X13 : ['X13']
+    X14 : ['X14']
+    X15 : ['X15']
+    X16 : ['X16']
+    X17 : ['X17']
+    X18 : ['X18']
+    X19 : ['X19']
+    X20 : ['X20']
+    X21 : ['X21']
+    X22 : ['X22']
+    X23 : ['X23']
+    X24 : ['X24']
+    X25 : ['X25']
+    X26 : ['X26']
+    X27 : ['X27']
+    X28 : ['X28']
+    X29 : ['X29']
+    X30 : ['X30']
+    X31 : ['X31']
+- Name: X0
+  Description: The X0 Integer Register (Stack Pointer)
+  Registers:
+    X0 : ['X0']
+- Name: spreg
+  Registers:
+    X2 : ['X2']
+  AddressBase: True
+- Name: X2
+  Description: The X2 Integer Register (Stack Pointer)
+  Register: 'X2'
+  AddressBase: True
+- Name: creg
+  Description: Compressed Instruction Integer Registers
+  Registers:
+    X8 : ['X8']
+    X9 : ['X9']
+    X10 : ['X10']
+    X11 : ['X11']
+    X12 : ['X12']
+    X13 : ['X13']
+    X14 : ['X14']
+    X15 : ['X15']
+- Name: crega
+  Description: Compressed Instruction Integer Registers
+  Registers:
+    X8 : ['X8']
+    X9 : ['X9']
+    X10 : ['X10']
+    X11 : ['X11']
+    X12 : ['X12']
+    X13 : ['X13']
+    X14 : ['X14']
+    X15 : ['X15']
+  AddressBase: True
+- Name: fcreg
+  Description: Compressed Instruction Floating Point Registers
+  Registers:
+    F8 : ['F8']
+    F9 : ['F9']
+    F10 : ['F10']
+    F11 : ['F11']
+    F12 : ['F12']
+    F13 : ['F13']
+    F14 : ['F14']
+    F15 : ['F15']
+- Name: 'imm20_clui'
+  Values:
+    - 1
+    - 2
+    - 3
+    - 4
+    - 5
+    - 6
+    - 7
+    - 8
+    - 9
+    - 10
+    - 11
+    - 12
+    - 13
+    - 14
+    - 15
+    - 16
+    - 17
+    - 18
+    - 19
+    - 20
+    - 21
+    - 22
+    - 23
+    - 24
+    - 25
+    - 26
+    - 27
+    - 28
+    - 29
+    - 30
+    - 31
+    - 0xfffe0
+    - 0xfffe1
+    - 0xfffe2
+    - 0xfffe3
+    - 0xfffe4
+    - 0xfffe5
+    - 0xfffe6
+    - 0xfffe7
+    - 0xfffe8
+    - 0xfffe9
+    - 0xfffea
+    - 0xfffeb
+    - 0xfffec
+    - 0xfffed
+    - 0xfffee
+    - 0xfffef
+    - 0xffff0
+    - 0xffff1
+    - 0xffff2
+    - 0xffff3
+    - 0xffff4
+    - 0xffff5
+    - 0xffff6
+    - 0xffff7
+    - 0xffff8
+    - 0xffff9
+    - 0xffffa
+    - 0xffffb
+    - 0xffffc
+    - 0xffffd
+    - 0xffffe
+    - 0xfffff

--- a/targets/riscv/isa/riscv-common/operand.yaml
+++ b/targets/riscv/isa/riscv-common/operand.yaml
@@ -115,11 +115,12 @@
   Min: 0
   Max: 127
   Step: 4
-- Name: imm8
-  Description: 8-bit immediate
+- Name: nz_imm8
+  Description: Non-zero 8-bit immediate
   Min: 0
   Max: 1023
   Step: 4
+  Except: [0]
 - Name: imm8_d
   Description: 8-bit immediate (Double Stepping)
   Min: 0
@@ -153,6 +154,12 @@
   Min: -512
   Max: 511
   Step: 16
+- Name: nz_imm10
+  Description: Non-zero 10-bit immediate
+  Min: -512
+  Max: 511
+  Step: 16
+  Except: [0]
 - Name: sbimm9
   Description: 9-bit signed immediate
   MinDisplacement: -256
@@ -299,6 +306,10 @@
   Description: 6-bit immediate
   Min: 0
   Max: 63
+- Name: nz_u.imm6
+  Description: Non-zero 6-bit immediate
+  Min: 1
+  Max: 63
 - Name: u.imm7
   Description: 7-bit immediate
   Min: 0
@@ -396,6 +407,9 @@
   Description: The X2 Integer Register (Stack Pointer)
   Register: 'X2'
   AddressBase: True
+- Name: X1
+  Description: The X1 Integer Register (Return Address)
+  Register: 'X1'
 - Name: creg
   Description: Compressed Instruction Integer Registers
   Registers:


### PR DESCRIPTION
This PR adds support for the RISCV C Extension to Microprobe.

For this implementation to work it was necessary to remove two (unusued) sanity checks.
- A masked value was tested to be different than 0, which is no longer true for some of the instructions in this extension of the architecture. 
- A check to make sure only one mnemonic could match the codification of an instruction. This was done before the different operands are tested. This check is removed because depending on the operands, one codification can be decoded to one instruction or another (e.g. if the register `src` being used is `x2` then it is instruction A, otherwise it will be instruction B).

It also includes some minor improvements of RISCV instruction codification fixes.