### PR TITLE
[RISCV] Implement ECALL & EBREAK instructions

### DIFF
--- a/targets/riscv/isa/riscv-common/instruction.yaml
+++ b/targets/riscv/isa/riscv-common/instruction.yaml
@@ -1748,3 +1748,15 @@
   Format: "i"
   Operands:
     funct3: ['4', 'funct3', '?']
+- Name: "ECALL_V0"
+  Mnemonic: "ECALL"
+  Opcode: "73"
+  Format: "sys"
+  Operands:
+    funct25: ['0', 'funct25', '?']
+- Name: "EBREAK_V0"
+  Mnemonic: "EBREAK"
+  Opcode: "73"
+  Format: "sys"
+  Operands:
+    funct25: ['8192', 'funct25', '?']

--- a/targets/riscv/isa/riscv-common/instruction_field.yaml
+++ b/targets/riscv/isa/riscv-common/instruction_field.yaml
@@ -65,6 +65,12 @@
   Show: True
   IO: "I"
   Operand: "imm7"
+- Name: "funct25"
+  Size: 25
+  Description: "funct25"
+  Show: False
+  IO: "?"
+  Operand: "imm25"
 - Name: "i_imm12"
   Size: 12
   Description: "i_imm12"

--- a/targets/riscv/isa/riscv-common/instruction_format.yaml
+++ b/targets/riscv/isa/riscv-common/instruction_format.yaml
@@ -396,3 +396,8 @@
   - rd
   - opcode
   Assembly: OPC rd, uj_imm20
+- Name: "sys"
+  Fields:
+  - funct25
+  - opcode
+  Assembly: OPC

--- a/targets/riscv/isa/riscv-common/operand.yaml
+++ b/targets/riscv/isa/riscv-common/operand.yaml
@@ -242,6 +242,10 @@
   Description: 7-bit immediate
   Min: 0
   Max: 127
+- Name: imm25
+  Description: 25-bit immediate
+  Min: 0
+  Max: 33554431
 - Name: rm
   Description: 3-bit immediate for rounding mode
   Values:


### PR DESCRIPTION
These were missing from the implementation of the base "I" extension.