### PR TITLE
Improve processing of binary regions in Microprobe Test (MPT) files

### DIFF
--- a/src/microprobe/utils/mpt.py
+++ b/src/microprobe/utils/mpt.py
@@ -1455,6 +1455,10 @@ class MicroprobeTestParserDefault(MicroprobeTestParser):
                             )
 
                             code_regions.append(code_region)
+                        elif len(code_regions) == 0:
+                            code_region = MicroprobeTestBinaryCodeRegion(None)
+
+                            code_regions.append(code_region)
                         else:
                             code_region = code_regions[-1]
 
@@ -2195,6 +2199,9 @@ class MicroprobeTestBinaryCodeRegion:
         return self._length
 
     def merge(self, other):
+        if (self.base_address() == None or other.base_address() == None):
+            return False;
+
         if (self.base_address() > other.base_address()):
             return other.merge(self)
 

--- a/src/microprobe/utils/mpt.py
+++ b/src/microprobe/utils/mpt.py
@@ -1454,8 +1454,7 @@ class MicroprobeTestParserDefault(MicroprobeTestParser):
                                 current_address
                             )
 
-                            if code_region is not None:
-                                code_regions.append(code_region)
+                            code_regions.append(code_region)
                         else:
                             code_region = code_regions[-1]
 
@@ -1646,9 +1645,6 @@ class MicroprobeTestParserDefault(MicroprobeTestParser):
         instruction_definitions = self._sort_by_instructions(
             instruction_definitions)
 
-        if code_region is not None:
-            code_regions.append(code_region)
-
         code_regions = self._merge_code_regions(code_regions)
 
         return (instruction_definitions, code_regions)
@@ -1657,15 +1653,13 @@ class MicroprobeTestParserDefault(MicroprobeTestParser):
         if len(code_regions) < 2:
             return code_regions
 
-        new_list = []
-        current_region = code_regions[0]
+        new_list = [code_regions[0]]
 
         for region in code_regions[1:]:
-            merged = current_region.merge(region)
+            merged = new_list[-1].merge(region)
 
             if not merged:
-                new_list.append(current_region)
-                current_region = region
+                new_list.append(region)
 
         return new_list
 
@@ -2204,7 +2198,7 @@ class MicroprobeTestBinaryCodeRegion:
         if (self.base_address() > other.base_address()):
             return other.merge(self)
 
-        end_address = self.base_address() + self.length
+        end_address = self.base_address() + self.length()
 
         if end_address == other.base_address():
             self.add_data(other.data())

--- a/targets/generic/tools/mp_mpt2c.py
+++ b/targets/generic/tools/mp_mpt2c.py
@@ -42,6 +42,7 @@ from microprobe.exceptions import MicroprobeException, \
     MicroprobeMPTFormatError, MicroprobeValueError
 from microprobe.target import import_definition
 from microprobe.utils.asm import interpret_asm
+from microprobe.utils.bin import interpret_bin
 from microprobe.utils.cmdline import new_file_ext, print_info, print_warning
 from microprobe.utils.logger import get_logger
 
@@ -64,10 +65,22 @@ def generate(test_definition, outputfile, target, **kwargs):
     """
 
     variables = test_definition.variables
+
+    sequence = []
+
     print_info("Interpreting assembly...")
-    sequence = interpret_asm(
-        test_definition.code, target, [var.name for var in variables]
-    )
+    if len(test_definition.code) > 0:
+        sequence.extend(interpret_asm(
+            test_definition.code, target, [var.name for var in variables]
+        ))
+
+    print_info("Interpreting binary code regions...")
+    region_count = len(test_definition.code_regions)
+    if region_count > 0:
+        for i in range(region_count):
+            print_info("[%d/%d]" % (i + 1, region_count + 1))
+            bin_data = test_definition.code_regions[i].data()
+            sequence.extend(interpret_bin(bin_data, target))
 
     if len(sequence) < 1:
         raise MicroprobeMPTFormatError(

--- a/targets/generic/tools/mp_mpt2c.py
+++ b/targets/generic/tools/mp_mpt2c.py
@@ -78,7 +78,7 @@ def generate(test_definition, outputfile, target, **kwargs):
     region_count = len(test_definition.code_regions)
     if region_count > 0:
         for i in range(region_count):
-            print_info("[%d/%d]" % (i + 1, region_count + 1))
+            print_info("[%d/%d]" % (i + 1, region_count))
             bin_data = test_definition.code_regions[i].data()
             sequence.extend(interpret_bin(bin_data, target))
 


### PR DESCRIPTION
Before this change, it was assumed that MPT files contained one instruction per line (in assembly or binary). If the code was in binary, then it was also assumed that the data would come in the correct sizes (i.e. the right instruction codification length).

However, this is not the case as Microprobe supports the decodification of binary streams of instructions of arbitrary lengths. Splitting the data into the appropiate lengths is therefore not the responsibility of the program generating the MPT, but  icroprobe's.

This commit changes the code so that the internal representation of MPT files contains both assembler code and binary code data in separate data structures to be processed separately (i.e. by utils/asm.py and utils/bin.py respectively).

Note that, although combining assembly and binary data in the MPT files is technically supported, the tool for generating C files
out of MPTs won't order those instructions correctly. I am not sure if this is a common use case or not. If necessary, this feature would be implemented in a later time (i.e. before accepting this Pull Request).