### PR TITLE
Endian-aware decoding

### DIFF
--- a/dev_tools/utils/check_instruction.py
+++ b/dev_tools/utils/check_instruction.py
@@ -24,13 +24,13 @@ target = import_definition(sys.argv[1])
 print(sys.argv[2:])
 
 for elem in sys.argv[2:]:
-    instr_def = interpret_bin(elem, target)[0]
+    instr_def = interpret_bin(elem, target, single=True)[0]
     instr = instruction_from_definition(instr_def)
     codification = int(instr.binary(), 2)
     assembly = instr.assembly()
     instr_def2 = interpret_asm(assembly, target, [])[0]
     print(hex(codification))
-    instr_def3 = interpret_bin(hex(codification)[2:], target)[0]
+    instr_def3 = interpret_bin(hex(codification)[2:], target, single=True)[0]
     instr2 = instruction_from_definition(instr_def2)
     instr3 = instruction_from_definition(instr_def3)
     assert instr.assembly() == instr2.assembly()

--- a/dev_tools/utils/check_instruction.py
+++ b/dev_tools/utils/check_instruction.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import sys
 from microprobe.target import import_definition
-from microprobe.utils.bin import interpret_bin
+from microprobe.utils.bin import interpret_bin_word
 from microprobe.code.ins import instruction_from_definition
 from microprobe.utils.asm import interpret_asm
 
@@ -24,13 +24,13 @@ target = import_definition(sys.argv[1])
 print(sys.argv[2:])
 
 for elem in sys.argv[2:]:
-    instr_def = interpret_bin(elem, target)[0]
+    instr_def = interpret_bin_word(elem, target)
     instr = instruction_from_definition(instr_def)
     codification = int(instr.binary(), 2)
     assembly = instr.assembly()
     instr_def2 = interpret_asm(assembly, target, [])[0]
     print(hex(codification))
-    instr_def3 = interpret_bin(hex(codification)[2:], target)[0]
+    instr_def3 = interpret_bin_word(hex(codification), target)
     instr2 = instruction_from_definition(instr_def2)
     instr3 = instruction_from_definition(instr_def3)
     assert instr.assembly() == instr2.assembly()

--- a/dev_tools/utils/check_instruction.py
+++ b/dev_tools/utils/check_instruction.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import
 from __future__ import print_function
 import sys
 from microprobe.target import import_definition
-from microprobe.utils.bin import interpret_bin_word
+from microprobe.utils.bin import interpret_bin
 from microprobe.code.ins import instruction_from_definition
 from microprobe.utils.asm import interpret_asm
 
@@ -24,13 +24,13 @@ target = import_definition(sys.argv[1])
 print(sys.argv[2:])
 
 for elem in sys.argv[2:]:
-    instr_def = interpret_bin_word(elem, target)
+    instr_def = interpret_bin(elem, target)[0]
     instr = instruction_from_definition(instr_def)
     codification = int(instr.binary(), 2)
     assembly = instr.assembly()
     instr_def2 = interpret_asm(assembly, target, [])[0]
     print(hex(codification))
-    instr_def3 = interpret_bin_word(hex(codification), target)
+    instr_def3 = interpret_bin(hex(codification)[2:], target)[0]
     instr2 = instruction_from_definition(instr_def2)
     instr3 = instruction_from_definition(instr_def3)
     assert instr.assembly() == instr2.assembly()

--- a/src/microprobe/utils/bin.py
+++ b/src/microprobe/utils/bin.py
@@ -89,6 +89,15 @@ def interpret_bin(
     if safe is None:
         safe = MICROPROBE_RC['safe_bin']
 
+    if single:
+        little_endian = False
+        if fmt == "hex":
+            word_length = math.ceil(len(code)/2)
+        elif fmt == "bin":
+            word_length = math.ceil(len(code)/8)
+        else:
+            raise MicroprobeBinaryError("Unknown format '%s'" % fmt)
+
     key = "%s-%s-%s-%s" % (code, target.name, fmt, safe)
 
     if key in _CODE_CACHE and _CODE_CACHE_ENABLED:

--- a/src/microprobe/utils/bin.py
+++ b/src/microprobe/utils/bin.py
@@ -61,10 +61,52 @@ _CODE_CACHE_ENABLED = True
 _BIN_CACHE_ENABLED = True
 
 __all__ = ["interpret_bin",
+           "interpret_bin_word",
            "MicroprobeBinInstructionStream", ]
 
 
 # Functions
+def interpret_bin_word(word, target, fmt="hex", safe=None):
+    """
+    Return the :class:`~.MicroprobeInstructionDefinition` object that results
+    from interpreting the *word* (a binary word corresponding to a single
+    instruction, in numeric positional notation i.e. big endian).
+    The *target* object is used to validate the existence of the instruction
+    and operands in the target.
+
+    :param word: String to interpret
+    :type word: :class:`~.str` object
+    :param target: Target definition
+    :type target: :class:`~.Target` object
+    :return: An instructions resulting from interpreting the word
+    :rtype: :class:`~.list` of :class:`~.MicroprobeInstructionDefinition`
+    :raise microprobe.exceptions.MicroprobeBinaryError: if something is wrong
+        during the interpretation
+    """
+    if fmt == "hex":
+        if word.startswith("0x"):
+            word = word[2:]
+
+        word_length = math.ceil(len(word)/2)
+    elif fmt == "bin":
+        if word.startswith("0b"):
+            word = word[2:]
+
+        word_length = math.ceil(len(word)/8)
+    else:
+        raise MicroprobeBinaryError(
+            "Unknown format '%s'" % fmt
+        )
+
+    print(word)
+    instructions = interpret_bin(word, target, fmt=fmt, safe=safe, single=True,
+                                 little_endian=False, word_length=word_length)
+
+    assert len(instructions) == 1
+
+    return instructions[0]
+
+
 def interpret_bin(
         code, target, fmt="hex", safe=None,
         single=False, little_endian=None, word_length=None

--- a/src/microprobe/utils/bin.py
+++ b/src/microprobe/utils/bin.py
@@ -61,52 +61,10 @@ _CODE_CACHE_ENABLED = True
 _BIN_CACHE_ENABLED = True
 
 __all__ = ["interpret_bin",
-           "interpret_bin_word",
            "MicroprobeBinInstructionStream", ]
 
 
 # Functions
-def interpret_bin_word(word, target, fmt="hex", safe=None):
-    """
-    Return the :class:`~.MicroprobeInstructionDefinition` object that results
-    from interpreting the *word* (a binary word corresponding to a single
-    instruction, in numeric positional notation i.e. big endian).
-    The *target* object is used to validate the existence of the instruction
-    and operands in the target.
-
-    :param word: String to interpret
-    :type word: :class:`~.str` object
-    :param target: Target definition
-    :type target: :class:`~.Target` object
-    :return: An instructions resulting from interpreting the word
-    :rtype: :class:`~.list` of :class:`~.MicroprobeInstructionDefinition`
-    :raise microprobe.exceptions.MicroprobeBinaryError: if something is wrong
-        during the interpretation
-    """
-    if fmt == "hex":
-        if word.startswith("0x"):
-            word = word[2:]
-
-        word_length = math.ceil(len(word)/2)
-    elif fmt == "bin":
-        if word.startswith("0b"):
-            word = word[2:]
-
-        word_length = math.ceil(len(word)/8)
-    else:
-        raise MicroprobeBinaryError(
-            "Unknown format '%s'" % fmt
-        )
-
-    print(word)
-    instructions = interpret_bin(word, target, fmt=fmt, safe=safe, single=True,
-                                 little_endian=False, word_length=word_length)
-
-    assert len(instructions) == 1
-
-    return instructions[0]
-
-
 def interpret_bin(
         code, target, fmt="hex", safe=None,
         single=False, little_endian=None, word_length=None

--- a/src/microprobe/utils/bin.py
+++ b/src/microprobe/utils/bin.py
@@ -67,7 +67,7 @@ __all__ = ["interpret_bin",
 # Functions
 def interpret_bin(
         code, target, fmt="hex", safe=None,
-        single=False, switch_endian=True
+        single=False, little_endian=None, word_length=None
         ):
     """
     Return the list of :class:`~.MicroprobeInstructionDefinition` objects
@@ -95,13 +95,15 @@ def interpret_bin(
         code = [instrdef.copy() for instrdef in _CODE_CACHE[key]]
     elif safe:
         code = _interpret_bin_code_safe(
-            code, target, single, fmt=fmt, switch_endian=switch_endian
+            code, target, single, fmt=fmt, little_endian=little_endian,
+            word_length=word_length
         )
         if _CODE_CACHE_ENABLED:
             _CODE_CACHE[key] = code[:]
     else:
         code = _interpret_bin_code(
-            code, target, single, fmt=fmt, switch_endian=switch_endian
+            code, target, single, fmt=fmt, little_endian=little_endian,
+            word_length=word_length
         )
         if _CODE_CACHE_ENABLED:
             _CODE_CACHE[key] = code[:]
@@ -110,13 +112,14 @@ def interpret_bin(
 
 
 def _interpret_bin_code(
-        code, target, single, fmt="hex", switch_endian=True
+        code, target, single, fmt="hex", little_endian=True, word_length=None
         ):
 
     instructions_and_params = []
 
     binstream = MicroprobeBinInstructionStream(
-        code, target, fmt=fmt, switch_endian=switch_endian
+        code, target, fmt=fmt, little_endian=little_endian,
+        word_length=word_length
     )
 
     while not binstream.empty():
@@ -130,7 +133,7 @@ def _interpret_bin_code(
 
 
 def _interpret_bin_code_safe(
-        code, target, single, fmt="hex", switch_endian=True
+        code, target, single, fmt="hex", little_endian=None, word_length=None
         ):
 
     instructions_and_params = []
@@ -138,7 +141,8 @@ def _interpret_bin_code_safe(
     binstream = MicroprobeBinInstructionStream(
         code, target, fmt=fmt,
         _data_cache=True,
-        switch_endian=switch_endian
+        little_endian=little_endian,
+        word_length=word_length
     )
 
     min_skip_length = min(
@@ -601,7 +605,9 @@ def _swap_bytes(original, little_endian=False):
     return result
 
 
-def _normalize_code(code, fmt="hex", little_endian=False):
+def _normalize_code(
+        code, fmt="hex", endianess_missmatch=False, word_length=None
+        ):
     """
 
     :param code:
@@ -639,6 +645,15 @@ def _normalize_code(code, fmt="hex", little_endian=False):
 
     code = "".join([char for char in code if char not in skip_character])
 
+    if endianess_missmatch:
+        LOG.debug("Fixing missmatch between input data and target's endianess")
+        assert word_length is not None
+        n = word_length * 2
+        words = [(code[i:i+n]) for i in range(0, len(code), n)]
+        code = ""
+        for word in words:
+            code += _swap_bytes(word, True)
+
     if fmt == "hex":
         return code
     elif fmt == "bin":
@@ -659,7 +674,7 @@ class MicroprobeBinInstructionStream(object):
 
     def __init__(
             self, code, target, fmt="hex",
-            _data_cache=False, switch_endian=True
+            _data_cache=False, little_endian=None, word_length=None
             ):
         """
 
@@ -670,11 +685,19 @@ class MicroprobeBinInstructionStream(object):
         """
 
         self._little_endian = target.little_endian
-        self._switch_endian = switch_endian
+
+        if little_endian is not None:
+            self._stream_little_endian = little_endian
+        else:
+            self._stream_little_endian = target.little_endian
+
+        endianess_missmatch = self._little_endian != self._stream_little_endian
+
         self._code = _normalize_code(
             code,
             fmt=fmt,
-            little_endian=self._little_endian
+            endianess_missmatch=endianess_missmatch,
+            word_length=word_length
         )
         self._fmt = fmt
         self._target = target
@@ -738,10 +761,9 @@ class MicroprobeBinInstructionStream(object):
                 continue
 
             bin_str = self._code[self._index:self._index + max_size]
-            if self._switch_endian:
-                bin_str = _swap_bytes(bin_str, self._little_endian)
             bin_str = bin_str[0:length * 2]
-            if self._switch_endian:
+
+            if self._little_endian:
                 bin_str = _swap_bytes(bin_str, self._little_endian)
 
             bin_int = int(bin_str, 16)

--- a/src/microprobe/utils/bin.py
+++ b/src/microprobe/utils/bin.py
@@ -92,9 +92,9 @@ def interpret_bin(
     if single:
         little_endian = False
         if fmt == "hex":
-            word_length = math.ceil(len(code)/2)
+            word_length = int(math.ceil(len(code)/2))
         elif fmt == "bin":
-            word_length = math.ceil(len(code)/8)
+            word_length = int(math.ceil(len(code)/8))
         else:
             raise MicroprobeBinaryError("Unknown format '%s'" % fmt)
 

--- a/targets/generic/tests/targets/targets_tests.py
+++ b/targets/generic/tests/targets/targets_tests.py
@@ -41,7 +41,7 @@ from microprobe.target import Target
 from microprobe.target.env import import_env_definition
 from microprobe.target.isa import import_isa_definition
 from microprobe.utils.asm import interpret_asm
-from microprobe.utils.bin import interpret_bin
+from microprobe.utils.bin import interpret_bin_word
 from microprobe.utils.logger import get_logger, set_log_level
 
 if six.PY2:
@@ -366,11 +366,7 @@ def self_codification_function(self):
                 print("Codification: 0x%x" % codification)
                 print("Assembly: %s" % instruction.assembly())
 
-                instr_def = interpret_bin(
-                    hex(codification)[2:],
-                    target,
-                    single=True
-                )[0]
+                instr_def = interpret_bin_word(hex(codification), target)
                 print("%s == %s ?" % (instr, instr_def.instruction_type))
 
                 self.assertEqual(instr.mnemonic,

--- a/targets/generic/tests/targets/targets_tests.py
+++ b/targets/generic/tests/targets/targets_tests.py
@@ -41,7 +41,7 @@ from microprobe.target import Target
 from microprobe.target.env import import_env_definition
 from microprobe.target.isa import import_isa_definition
 from microprobe.utils.asm import interpret_asm
-from microprobe.utils.bin import interpret_bin_word
+from microprobe.utils.bin import interpret_bin
 from microprobe.utils.logger import get_logger, set_log_level
 
 if six.PY2:
@@ -366,7 +366,11 @@ def self_codification_function(self):
                 print("Codification: 0x%x" % codification)
                 print("Assembly: %s" % instruction.assembly())
 
-                instr_def = interpret_bin_word(hex(codification), target)
+                instr_def = interpret_bin(
+                    hex(codification)[2:],
+                    target,
+                    single=True
+                )[0]
                 print("%s == %s ?" % (instr, instr_def.instruction_type))
 
                 self.assertEqual(instr.mnemonic,

--- a/targets/generic/tools/mp_mpt2c.py
+++ b/targets/generic/tools/mp_mpt2c.py
@@ -135,8 +135,13 @@ def generate(test_definition, outputfile, target, **kwargs):
 
         sequence = []
         for address in sorted(raw_dict.keys()):
+
+            # Endianess will be big endian, because we are concatenating
+            # full words resulting in the higher bits being encoded first
+
             code = interpret_bin(
-                raw_dict[address], target, safe=True, switch_endian=False
+                raw_dict[address], target, safe=True, little_endian=False,
+                word_length=4
             )
             code[0].address = address
             sequence.extend(code)


### PR DESCRIPTION
In this PR I implemented the changes suggested in the issue #28 . The main idea is to be aware of the endianess of both the input binary stream of instructions and the target's. If there is a mismatch, the endianess of the input data must be changed so it is the expected one (i.e. the target's). To do this, the word size of the input data is also needed, so it is passed as an additional parameter (only required if there is an endianess mismatch). Finally, a minor tweak is done when interpreting each "chunk" of data corresponding to an instruction so that, in case we are working with little endian encoding, the data is transformed once more in order to work with the usual positional notation (i.e. big endians).

Due to changes in the interfaces of the functions, some more code had to be changed. This is mainly for the test code. To aid with that, an additional helper function was implemented which decodes a single instruction from a single word in positional notation. This function uses the existing ones and sets these new parameters to their appropriate values.

Because of this, I had to modify a bit more code than I was expecting. If there is anything which is not quite right, please feel free to change it or leave a comment.