### PR TITLE
[RISCV] Miscellaneous improvements and fixes

### DIFF
--- a/targets/riscv/isa/riscv-common/instruction.yaml
+++ b/targets/riscv/isa/riscv-common/instruction.yaml
@@ -358,34 +358,34 @@
     sb_imm7: ['@sb_imm7', 'sb_imm7', 'I']
   MemoryOperands:
     MEM1 : [['@sb_imm7'], [0], 0, 'B']
-- Name: "CUSTOM0_V0"
-  Mnemonic: "CUSTOM0"
-  Opcode: "b"
-  Description: "Custom instruction 0"
-  Format: "custom"
-  Operands:
-    funct3: ['7', 'funct3', '?']
-- Name: "CUSTOM1_V0"
-  Mnemonic: "CUSTOM1"
-  Opcode: "2b"
-  Description: "Custom instruction 1"
-  Format: "custom"
-  Operands:
-    funct3: ['7', 'funct3', '?']
-- Name: "CUSTOM2_V0"
-  Mnemonic: "CUSTOM2"
-  Opcode: "5b"
-  Description: "Custom instruction 2"
-  Format: "custom"
-  Operands:
-    funct3: ['7', 'funct3', '?']
-- Name: "CUSTOM3_V0"
-  Mnemonic: "CUSTOM3"
-  Opcode: "7b"
-  Description: "Custom instruction 3"
-  Format: "custom"
-  Operands:
-    funct3: ['7', 'funct3', '?']
+    #- Name: "CUSTOM0_V0"
+    #  Mnemonic: "CUSTOM0"
+    #  Opcode: "b"
+    #  Description: "Custom instruction 0"
+    #  Format: "custom"
+    #  Operands:
+    #    funct3: ['7', 'funct3', '?']
+    #- Name: "CUSTOM1_V0"
+    #  Mnemonic: "CUSTOM1"
+    #  Opcode: "2b"
+    #  Description: "Custom instruction 1"
+    #  Format: "custom"
+    #  Operands:
+    #    funct3: ['7', 'funct3', '?']
+    #- Name: "CUSTOM2_V0"
+    #  Mnemonic: "CUSTOM2"
+    #  Opcode: "5b"
+    #  Description: "Custom instruction 2"
+    #  Format: "custom"
+    #  Operands:
+    #    funct3: ['7', 'funct3', '?']
+    #- Name: "CUSTOM3_V0"
+    #  Mnemonic: "CUSTOM3"
+    #  Opcode: "7b"
+    #  Description: "Custom instruction 3"
+    #  Format: "custom"
+    #  Operands:
+    #    funct3: ['7', 'funct3', '?']
 - Name: "DIV_V0"
   Mnemonic: "DIV"
   Opcode: "33"
@@ -1942,6 +1942,7 @@
   Format: "ci_ls"
   Operands:
     funct3: ['0', 'funct3', '?']
+    rd: ['nzreg', 'rd', 'IO']
 - Name: "C.FLDSP_V0"
   Mnemonic: "C.FLDSP"
   Opcode: "2"

--- a/targets/riscv/isa/riscv-common/isa.py
+++ b/targets/riscv/isa/riscv-common/isa.py
@@ -96,7 +96,7 @@ class RISCVISA(GenericISA):
                 instrs += self.set_register(self._scratch_registers[0], value,
                                             context)
 
-                instr = self.new_instruction("FCVT.S.L_V0")
+                instr = self.new_instruction("FMV.D.X_V0")
                 instr.set_operands([self._scratch_registers[0], register])
                 instrs.append(instr)
 
@@ -140,17 +140,15 @@ class RISCVISA(GenericISA):
 
                     LOG.debug("This is the scratch register. Long path")
 
+                    if value_high > 2047:
+                        value_highest = value_highest + 1
+                        value_high = value_high - (4096)
+
                     lui = self.new_instruction("LUI_V0")
                     lui.set_operands([value_highest, register])
                     instrs.append(lui)
+
                     addiw = self.new_instruction("ADDIW_V0")
-
-                    if value_high >= (2**11-1):
-                        addiw.set_operands([2**11-1, register, register])
-                        instrs.append(addiw)
-                        addiw = self.new_instruction("ADDIW_V0")
-                        value_high = value_high - (2**11-1)
-
                     addiw.set_operands([value_high, register, register])
                     instrs.append(addiw)
 

--- a/targets/riscv/isa/riscv-common/operand.yaml
+++ b/targets/riscv/isa/riscv-common/operand.yaml
@@ -102,6 +102,7 @@
   Description: 6-bit immediate (signed)
   Min: -32
   Max: 31
+  Except: [0]
 - Name: imm6
   Description: 6-bit immediate
   Min: 0


### PR DESCRIPTION
- Disable invalid "CUSTOMX_V0" instructions
- Use FMV instead of FCVT instructions to set the binary representation of a floating point value instead of converting the value of the source register to an FP number.
- Fix the setting of register contents when the value is large
- Require a non-zero immediate for C.ADDI
- Require a non-X0 register as rd for C.SLLI