### PR TITLE
Fix incorrect Context class copy constructor

### DIFF
--- a/src/microprobe/code/context.py
+++ b/src/microprobe/code/context.py
@@ -90,7 +90,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
         )
         newcontext._memory_values[0] = smart_copy_dict(self._memory_values[0])
         newcontext._memory_values[1] = smart_copy_dict(
-            self._register_values[1]
+            self._memory_values[1]
         )
 
         if self._dat is not None:


### PR DESCRIPTION
This series fixes a minor issue with the Context class' `.copy()` constructor.

Commits:
1. Fixes the issue (uses the corresponding `_memory_values[1]` field rather than `_register_values[1]`). 
2. Adds the type hints that helped me catch this issue (and enable python tooling to provide types!).
3. Minor refactoring to improve readability and allow us to add type hinting to the `_register_values` and `_memory_values` variables.

I have other type hints that I use when developing locally & would be happy to upstream them as they really help python tooling detect issues.

These type hints were added using my best guess & the surrounding context. I've annotated most of the project in my local clone, so I extracted these types from that. I'm happy to make changes if there are any issues!