### PR TITLE
Add type hints to `src/microprobe/code` folder

### DIFF
--- a/src/microprobe/code/__init__.py
+++ b/src/microprobe/code/__init__.py
@@ -45,7 +45,7 @@ import copy
 import datetime
 import os
 from time import time
-from typing import TYPE_CHECKING, Dict, List
+from typing import TYPE_CHECKING, Dict, List, Type
 
 # Third party modules
 import six
@@ -81,6 +81,10 @@ _INIT = True
 __all__ = ['get_wrapper', 'Synthesizer']
 
 
+def _wrapper_subclasses() -> List[Type[microprobe.code.wrapper.Wrapper]]:
+    return get_all_subclasses(microprobe.code.wrapper.Wrapper)
+
+
 # Functions
 def get_wrapper(name: str):
     """Return a wrapper object with name *name*.
@@ -102,15 +106,13 @@ def get_wrapper(name: str):
     if MICROPROBE_RC['debugwrapper']:
         name = "DebugBinaryDouble"
 
-    for elem in get_all_subclasses(microprobe.code.wrapper.Wrapper):
+    for elem in _wrapper_subclasses():
         if elem.__name__ == name:
             return elem
 
     raise MicroprobeValueError(
-        "Unknown wrapper '%s'. Available wrappers are: %s. " % (name, [
-            elem.__name__
-            for elem in get_all_subclasses(microprobe.code.wrapper.Wrapper)
-        ]))
+        "Unknown wrapper '%s'. Available wrappers are: %s. " %
+        (name, [elem.__name__ for elem in _wrapper_subclasses()]))
 
 
 def _import_default_wrappers():
@@ -147,7 +149,7 @@ def _import_default_wrappers():
 
             current_wrappers = \
                 [elem.__name__ for elem in
-                 get_all_subclasses(microprobe.code.wrapper.Wrapper)
+                 _wrapper_subclasses()
                  ]
 
             if len(current_wrappers) != len(set(current_wrappers)):

--- a/src/microprobe/code/__init__.py
+++ b/src/microprobe/code/__init__.py
@@ -68,7 +68,6 @@ from microprobe.utils.misc import OrderedDict, findfiles, Progress, \
 
 # Local modules
 
-
 # Constants
 
 #: Package logger (:class:`~.logging.Logger`).
@@ -104,15 +103,10 @@ def get_wrapper(name):
             return elem
 
     raise MicroprobeValueError(
-        "Unknown wrapper '%s'. Available wrappers are: %s. " % (
-            name, [
-                elem.__name__
-                for elem in get_all_subclasses(
-                    microprobe.code.wrapper.Wrapper
-                )
-            ]
-        )
-    )
+        "Unknown wrapper '%s'. Available wrappers are: %s. " % (name, [
+            elem.__name__
+            for elem in get_all_subclasses(microprobe.code.wrapper.Wrapper)
+        ]))
 
 
 def _import_default_wrappers():
@@ -137,8 +131,7 @@ def _import_default_wrappers():
             if name in microprobe.code.wrapper.__dict__:
                 raise MicroprobeError(
                     "Wrapper module name '%s' in '%s' already loaded. " %
-                    (name, module_file)
-                )
+                    (name, module_file))
 
             try:
                 module = load_source(name, module_file)
@@ -159,8 +152,7 @@ def _import_default_wrappers():
                 overwrapper = list(set(current_wrappers))[0]
                 raise MicroprobeError(
                     "Module name '%s' in '%s' overrides an existing wrapper "
-                    "with name '%s'" % (name, module_file, overwrapper)
-                )
+                    "with name '%s'" % (name, module_file, overwrapper))
 
 
 # Classes
@@ -267,8 +259,7 @@ class Synthesizer(object):
                 raise MicroprobeCodeGenerationError(
                     "Number of wrappers provided (%d) is different from "
                     "number of threads (%d) specified in the Synthesizer" %
-                    (len(wrapper), self._threads)
-                )
+                    (len(wrapper), self._threads))
             self._wrappers = wrapper
         else:
             self._wrappers = [wrapper]
@@ -301,9 +292,8 @@ class Synthesizer(object):
         else:
             if not 1 <= thread_idx <= self._threads + 1:
                 raise MicroprobeCodeGenerationError(
-                    "Unknown thread id: %d (min: 1, max: %d)"
-                    % (thread_idx, self._threads + 1)
-                )
+                    "Unknown thread id: %d (min: 1, max: %d)" %
+                    (thread_idx, self._threads + 1))
             self._passes[thread_idx].append(synth_pass)
 
     def save(self, name, bench=None, pad=None):
@@ -324,13 +314,8 @@ class Synthesizer(object):
         starttime = time()
         program_str = self._wrap(bench)
         endtime = time()
-        LOG.info(
-            "Pass wrap: %s", (
-                datetime.timedelta(
-                    seconds=endtime - starttime
-                )
-            )
-        )
+        LOG.info("Pass wrap: %s",
+                 (datetime.timedelta(seconds=endtime - starttime)))
 
         outputname = self._wrappers[0].outputname(name)
         fdx = open_generic_fd(outputname, 'wb')
@@ -388,8 +373,7 @@ class Synthesizer(object):
             # Basic context
             reserved_registers = self._target.reserved_registers
             reserved_registers += self.wrapper.reserved_registers(
-                reserved_registers, self._target
-            )
+                reserved_registers, self._target)
 
             bench.context.add_reserved_registers(reserved_registers)
 
@@ -412,12 +396,9 @@ class Synthesizer(object):
                 step(bench, self.target)
                 bench.add_pass_info(step.info())
                 endtime = time()
-                LOG.debug(
-                    "Applying pass %03d: %s : Execution time: %s",
-                    idx,
-                    step.__class__.__name__,
-                    datetime.timedelta(seconds=endtime - starttime)
-                )
+                LOG.debug("Applying pass %03d: %s : Execution time: %s", idx,
+                          step.__class__.__name__,
+                          datetime.timedelta(seconds=endtime - starttime))
                 starttime = endtime
 
             starttime = time()
@@ -428,36 +409,26 @@ class Synthesizer(object):
                 try:
                     pass_ok = step.check(bench, self.target)
                 except NotImplementedError:
-                    LOG.warning(
-                        "Checking pass %03d: %s. NOT IMPLEMENTED", idx,
-                        step.__class__.__name__
-                    )
+                    LOG.warning("Checking pass %03d: %s. NOT IMPLEMENTED", idx,
+                                step.__class__.__name__)
                     pass_ok = False
 
                 endtime = time()
 
                 if not pass_ok:
-                    LOG.warning(
-                        "Checking pass %03d: %s. Test result: FAIL", idx,
-                        step.__class__.__name__
-                    )
+                    LOG.warning("Checking pass %03d: %s. Test result: FAIL",
+                                idx, step.__class__.__name__)
 
                     bench.add_warning(
                         "Pass %03d: %s did not pass the check test" %
-                        (idx, step.__class__.__name__)
-                    )
+                        (idx, step.__class__.__name__))
                 else:
-                    LOG.debug(
-                        "Checking pass %03d: %s. Test result: OK", idx,
-                        step.__class__.__name__
-                    )
+                    LOG.debug("Checking pass %03d: %s. Test result: OK", idx,
+                              step.__class__.__name__)
 
-                LOG.debug(
-                    "Checking pass %03d: %s : Execution time: %s",
-                    idx,
-                    step.__class__.__name__,
-                    datetime.timedelta(seconds=endtime - starttime)
-                )
+                LOG.debug("Checking pass %03d: %s : Execution time: %s", idx,
+                          step.__class__.__name__,
+                          datetime.timedelta(seconds=endtime - starttime))
 
                 starttime = endtime
 
@@ -495,10 +466,7 @@ class Synthesizer(object):
         for var in bench.registered_global_vars():
             if var.value is None:
                 thread_str.append(
-                    self.wrapper.init_global_var(
-                        var, self._immediate
-                    )
-                )
+                    self.wrapper.init_global_var(var, self._immediate))
 
         thread_str.append(self.wrapper.post_var())
 
@@ -518,18 +486,14 @@ class Synthesizer(object):
                     first = False
                     if bench.init:
                         code_str.append(
-                            self.wrapper.start_loop(
-                                instr, bench.init[0]
-                            )
-                        )
+                            self.wrapper.start_loop(instr, bench.init[0]))
                     else:
                         code_str.append(self.wrapper.start_loop(instr, instr))
                 code_str.append(self.wrapper.wrap_ins(instr))
 
         if instr is None:
             raise MicroprobeCodeGenerationError(
-                "No instructions found in benchmark"
-            )
+                "No instructions found in benchmark")
 
         thread_str.extend(code_str)
 
@@ -576,10 +540,8 @@ class Synthesizer(object):
         for thread_id in range(1, self._threads + 1):
             self.set_current_thread(thread_id)
             bench.set_current_thread(thread_id)
-            for var in sorted(
-                    bench.registered_global_vars(),
-                    key=lambda x: x.address
-            ):
+            for var in sorted(bench.registered_global_vars(),
+                              key=lambda x: x.address):
                 bench_str.append(self.wrapper.declare_global_var(var))
 
         for thread_id in range(1, self._threads + 1):
@@ -599,9 +561,8 @@ class Synthesizer(object):
         self._current_thread = idx
         if not 1 <= idx <= self._threads + 1:
             raise MicroprobeCodeGenerationError(
-                "Unknown thread id: %d (min: 1, max: %d)" % (idx,
-                                                             self._threads + 1)
-            )
+                "Unknown thread id: %d (min: 1, max: %d)" %
+                (idx, self._threads + 1))
 
 
 class TraceSynthesizer(Synthesizer):
@@ -625,8 +586,7 @@ class TraceSynthesizer(Synthesizer):
     """
 
     def __init__(self, target, wrapper, **kwargs):
-        super(TraceSynthesizer, self).__init__(target, wrapper,
-                                               **kwargs)
+        super(TraceSynthesizer, self).__init__(target, wrapper, **kwargs)
 
         self._show_trace = kwargs.get("show_trace", False)
         self._maxins = kwargs.get("maxins", 10000)
@@ -683,20 +643,15 @@ class TraceSynthesizer(Synthesizer):
                     self._start_addr
                 ][0]
             else:
-                instr = instructions_dict[
-                    InstructionAddress(
-                        base_address="code",
-                        displacement=(
-                            self._start_addr - bench.context.code_segment
-                        )
-                    )
-                ]
+                instr = instructions_dict[InstructionAddress(
+                    base_address="code",
+                    displacement=(self._start_addr -
+                                  bench.context.code_segment))]
 
         count = 0
 
-        cmd.cmdline.print_info(
-            "Maximum trace size: %s instructions " %
-            self._maxins)
+        cmd.cmdline.print_info("Maximum trace size: %s instructions " %
+                               self._maxins)
 
         progress = Progress(self._maxins, msg="Instructions generated:")
 
@@ -722,16 +677,14 @@ class TraceSynthesizer(Synthesizer):
                 if instr.mnemonic.upper() == "ATTN":
                     cmd.cmdline.print_warning(
                         "Processor ATTN instruction found. Stopping trace "
-                        "generation. "
-                    )
+                        "generation. ")
                     break
 
                 cmd.cmdline.print_error(
                     "Jump from 0x%X to an unknown instruction in address "
                     "0x%X found. Stoping trace generation." %
                     (instr.address.displacement + bench.context.code_segment,
-                     instr_address.displacement + bench.context.code_segment)
-                )
+                     instr_address.displacement + bench.context.code_segment))
                 exit(-1)
 
             progress()
@@ -739,9 +692,7 @@ class TraceSynthesizer(Synthesizer):
                                              next_instr=next_instr,
                                              show=self._show_trace)
 
-            bench_str.append(
-                wrap_ins
-            )
+            bench_str.append(wrap_ins)
 
             instr = next_instr
 

--- a/src/microprobe/code/address.py
+++ b/src/microprobe/code/address.py
@@ -16,10 +16,11 @@
 """
 
 # Futures
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, annotations, print_function
 
 # Built in modules
 import hashlib
+from typing import TYPE_CHECKING
 
 # Third party modules
 import six
@@ -29,6 +30,10 @@ from microprobe.code.var import Variable
 from microprobe.exceptions import MicroprobeCodeGenerationError
 from microprobe.utils.logger import get_logger
 
+# Type hinting
+if TYPE_CHECKING:
+    from microprobe.code.ins import Instruction
+
 # Constants
 LOG = get_logger(__name__)
 __all__ = ["MemoryValue", "Address", "InstructionAddress"]
@@ -37,12 +42,14 @@ __all__ = ["MemoryValue", "Address", "InstructionAddress"]
 
 
 # Classes
-class Address(object):
+class Address:
     """Class to represent an address."""
 
     _cmp_attributes = ["_base_address", "_displacement"]
 
-    def __init__(self, base_address=None, displacement=0):
+    def __init__(self,
+                 base_address: Variable | str | None = None,
+                 displacement: int = 0):
         """
 
         :param base_address:  (Default value = None)
@@ -65,7 +72,7 @@ class Address(object):
         self._hash = None
 
     @property
-    def base_address(self):
+    def base_address(self) -> Variable | str | None:
         """Base address of the address (:class:`~.str`)"""
         return self._base_address
 
@@ -74,7 +81,7 @@ class Address(object):
         """Displacement of the address (:class:`~.int`)"""
         return self._displacement
 
-    def check_alignment(self, align):
+    def check_alignment(self, align: int):
         """Check if the address is aligned to align"""
         return self._displacement % align == 0
 
@@ -83,7 +90,7 @@ class Address(object):
         return self.__class__(base_address=self.base_address,
                               displacement=self.displacement)
 
-    def __add__(self, other):
+    def __add__(self, other: Address | int):
         """
 
         :param other:
@@ -106,12 +113,12 @@ class Address(object):
         else:
             raise NotImplementedError
 
-    def _check_cmp(self, other):
+    def _check_cmp(self, other: Address):
         if not isinstance(other, self.__class__):
             raise NotImplementedError("%s != %s" %
                                       (other.__class__, self.__class__))
 
-    def __eq__(self, other):
+    def __eq__(self, other: object):
         """x.__eq__(y) <==> x==y"""
 
         if not isinstance(other, self.__class__):
@@ -122,7 +129,7 @@ class Address(object):
                 return False
         return True
 
-    def __ne__(self, other):
+    def __ne__(self, other: object):
         """x.__ne__(y) <==> x!=y"""
 
         if not isinstance(other, self.__class__):
@@ -133,7 +140,7 @@ class Address(object):
                 return True
         return False
 
-    def __lt__(self, other):
+    def __lt__(self, other: object):
         """x.__lt__(y) <==> x<y"""
 
         if not isinstance(other, self.__class__):
@@ -146,7 +153,7 @@ class Address(object):
                 return False
         return False
 
-    def __gt__(self, other):
+    def __gt__(self, other: object):
         """x.__gt__(y) <==> x>y"""
 
         if not isinstance(other, self.__class__):
@@ -159,7 +166,7 @@ class Address(object):
                 return False
         return False
 
-    def __le__(self, other):
+    def __le__(self, other: object):
         """x.__le__(y) <==> x<=y"""
 
         if not isinstance(other, self.__class__):
@@ -172,7 +179,7 @@ class Address(object):
                 return False
         return True
 
-    def __ge__(self, other):
+    def __ge__(self, other: object):
         """x.__ge__(y) <==> x>=y"""
 
         if not isinstance(other, self.__class__):
@@ -192,7 +199,7 @@ class Address(object):
                 hashlib.sha512(str(self).encode()).hexdigest(), 16)
         return self._hash
 
-    def __iadd__(self, other):
+    def __iadd__(self, other: object):
         """
 
         :param other:
@@ -216,7 +223,7 @@ class Address(object):
         else:
             raise NotImplementedError
 
-    def __mod__(self, other):
+    def __mod__(self, other: object):
         """
 
         :param other:
@@ -243,7 +250,7 @@ class Address(object):
         else:
             raise NotImplementedError
 
-    def __radd__(self, other):
+    def __radd__(self, other: object):
         """
 
         :param other:
@@ -271,7 +278,7 @@ class Address(object):
         return "%s(%s+0x%016x)" % (self.__class__.__name__, self.base_address,
                                    self.displacement)
 
-    def __rsub__(self, other):
+    def __rsub__(self, other: object):
         """
 
         :param other:
@@ -298,7 +305,7 @@ class Address(object):
         return "%s(%s+0x%016x)" % (self.__class__.__name__, self.base_address,
                                    self.displacement)
 
-    def __sub__(self, other):
+    def __sub__(self, other: object):
         """
 
         :param other:
@@ -325,7 +332,10 @@ class Address(object):
 class InstructionAddress(Address):
     """Class to represent an instruction address."""
 
-    def __init__(self, base_address=None, displacement=0, instruction=None):
+    def __init__(self,
+                 base_address: Variable | str | None = None,
+                 displacement: int = 0,
+                 instruction: Instruction | None = None):
         """
 
         :param base_address:  (Default value = None)
@@ -342,7 +352,7 @@ class InstructionAddress(Address):
         """Target instruction (:class:`~.Instruction`)"""
         return self._instruction
 
-    def set_target_instruction(self, instruction):
+    def set_target_instruction(self, instruction: Instruction):
         """Sets the instruction to which this address is pointing.
 
         :param instruction: Target instruction
@@ -352,7 +362,7 @@ class InstructionAddress(Address):
 
         self._instruction = instruction
 
-    def __add__(self, other):
+    def __add__(self, other: Address | int):
         """
 
         :param other:
@@ -361,7 +371,7 @@ class InstructionAddress(Address):
         self._instruction = None
         return super(InstructionAddress, self).__add__(other)
 
-    def __iadd__(self, other):
+    def __iadd__(self, other: object):
         """
 
         :param other:
@@ -370,7 +380,7 @@ class InstructionAddress(Address):
         self._instruction = None
         return super(InstructionAddress, self).__iadd__(other)
 
-    def __mod__(self, other):
+    def __mod__(self, other: object):
         """
 
         :param other:
@@ -379,7 +389,7 @@ class InstructionAddress(Address):
         self._instruction = None
         return super(InstructionAddress, self).__mod__(other)
 
-    def __radd__(self, other):
+    def __radd__(self, other: object):
         """
 
         :param other:
@@ -388,7 +398,7 @@ class InstructionAddress(Address):
         self._instruction = None
         return super(InstructionAddress, self).__radd__(other)
 
-    def __rsub__(self, other):
+    def __rsub__(self, other: object):
         """
 
         :param other:
@@ -397,7 +407,7 @@ class InstructionAddress(Address):
         self._instruction = None
         return super(InstructionAddress, self).__rsub__(other)
 
-    def __sub__(self, other):
+    def __sub__(self, other: object):
         """
 
         :param other:
@@ -412,7 +422,7 @@ class MemoryValue(object):
 
     _cmp_attributes = ['address', 'value', 'length']
 
-    def __init__(self, address, value, length):
+    def __init__(self, address: Address, value: int, length: int):
         """
 
         :param address:
@@ -442,12 +452,12 @@ class MemoryValue(object):
         """Actual memory value (:class:`~.int`)"""
         return self._value
 
-    def _check_cmp(self, other):
+    def _check_cmp(self, other: object):
         if not isinstance(other, self.__class__):
             raise NotImplementedError("%s != %s" %
                                       (other.__class__, self.__class__))
 
-    def __eq__(self, other):
+    def __eq__(self, other: object):
         """x.__eq__(y) <==> x==y"""
         self._check_cmp(other)
         for attr in self._cmp_attributes:
@@ -455,7 +465,7 @@ class MemoryValue(object):
                 return False
         return True
 
-    def __ne__(self, other):
+    def __ne__(self, other: object):
         """x.__ne__(y) <==> x!=y"""
         self._check_cmp(other)
         for attr in self._cmp_attributes:
@@ -463,7 +473,7 @@ class MemoryValue(object):
                 return True
         return False
 
-    def __lt__(self, other):
+    def __lt__(self, other: object):
         """x.__lt__(y) <==> x<y"""
         self._check_cmp(other)
         for attr in self._cmp_attributes:
@@ -473,7 +483,7 @@ class MemoryValue(object):
                 return False
         return False
 
-    def __gt__(self, other):
+    def __gt__(self, other: object):
         """x.__gt__(y) <==> x>y"""
         self._check_cmp(other)
         for attr in self._cmp_attributes:
@@ -483,7 +493,7 @@ class MemoryValue(object):
                 return False
         return False
 
-    def __le__(self, other):
+    def __le__(self, other: object):
         """x.__le__(y) <==> x<=y"""
         self._check_cmp(other)
         for attr in self._cmp_attributes:
@@ -493,7 +503,7 @@ class MemoryValue(object):
                 return False
         return True
 
-    def __ge__(self, other):
+    def __ge__(self, other: object):
         """x.__ge__(y) <==> x>=y"""
         self._check_cmp(other)
         for attr in self._cmp_attributes:

--- a/src/microprobe/code/address.py
+++ b/src/microprobe/code/address.py
@@ -29,7 +29,6 @@ from microprobe.code.var import Variable
 from microprobe.exceptions import MicroprobeCodeGenerationError
 from microprobe.utils.logger import get_logger
 
-
 # Constants
 LOG = get_logger(__name__)
 __all__ = ["MemoryValue", "Address", "InstructionAddress"]
@@ -81,10 +80,8 @@ class Address(object):
 
     def copy(self):
         """Returns a copy of the address."""
-        return self.__class__(
-            base_address=self.base_address,
-            displacement=self.displacement
-        )
+        return self.__class__(base_address=self.base_address,
+                              displacement=self.displacement)
 
     def __add__(self, other):
         """
@@ -96,14 +93,11 @@ class Address(object):
         if isinstance(other, self.__class__):
 
             if self.base_address != other.base_address:
-                raise MicroprobeCodeGenerationError(
-                    "I can not add '%s' "
-                    "and '%s'" % (self, other)
-                )
+                raise MicroprobeCodeGenerationError("I can not add '%s' "
+                                                    "and '%s'" % (self, other))
 
-            return self.__class__(
-                self.base_address, self.displacement + other.displacement
-            )
+            return self.__class__(self.base_address,
+                                  self.displacement + other.displacement)
 
         elif isinstance(other, six.integer_types):
 
@@ -114,11 +108,8 @@ class Address(object):
 
     def _check_cmp(self, other):
         if not isinstance(other, self.__class__):
-            raise NotImplementedError(
-                "%s != %s" % (
-                    other.__class__, self.__class__
-                )
-            )
+            raise NotImplementedError("%s != %s" %
+                                      (other.__class__, self.__class__))
 
     def __eq__(self, other):
         """x.__eq__(y) <==> x==y"""
@@ -198,8 +189,7 @@ class Address(object):
         """ """
         if self._hash is None:
             self._hash = int(
-                hashlib.sha512(str(self).encode()).hexdigest(), 16
-            )
+                hashlib.sha512(str(self).encode()).hexdigest(), 16)
         return self._hash
 
     def __iadd__(self, other):
@@ -212,16 +202,12 @@ class Address(object):
         if isinstance(other, self.__class__):
 
             if self.base_address != other.base_address:
-                raise MicroprobeCodeGenerationError(
-                    "I can not add '%s'"
-                    " and '%s'" % (
-                        self, other
-                    )
-                )
+                raise MicroprobeCodeGenerationError("I can not add '%s'"
+                                                    " and '%s'" %
+                                                    (self, other))
 
-            return self.__class__(
-                self.base_address, self.displacement + other.displacement
-            )
+            return self.__class__(self.base_address,
+                                  self.displacement + other.displacement)
 
         elif isinstance(other, six.integer_types):
 
@@ -240,14 +226,12 @@ class Address(object):
         if isinstance(other, self.__class__):
 
             if self.base_address != other.base_address:
-                raise MicroprobeCodeGenerationError(
-                    "I can not compute the "
-                    "module '%s' and '%s'" % (self, other)
-                )
+                raise MicroprobeCodeGenerationError("I can not compute the "
+                                                    "module '%s' and '%s'" %
+                                                    (self, other))
 
-            return self.__class__(
-                self.base_address, self.displacement + other.displacement
-            )
+            return self.__class__(self.base_address,
+                                  self.displacement + other.displacement)
 
         elif isinstance(other, six.integer_types):
 
@@ -269,14 +253,11 @@ class Address(object):
         if isinstance(other, self.__class__):
 
             if self.base_address != other.base_address:
-                raise MicroprobeCodeGenerationError(
-                    "I can not add '%s' and "
-                    "'%s'" % (self, other)
-                )
+                raise MicroprobeCodeGenerationError("I can not add '%s' and "
+                                                    "'%s'" % (self, other))
 
-            return self.__class__(
-                self.base_address, self.displacement + other.displacement
-            )
+            return self.__class__(self.base_address,
+                                  self.displacement + other.displacement)
 
         elif isinstance(other, six.integer_types):
             return self.__class__(self.base_address, self.displacement + other)
@@ -287,9 +268,8 @@ class Address(object):
     def __repr__(self):
         """ """
 
-        return "%s(%s+0x%016x)" % (
-            self.__class__.__name__, self.base_address, self.displacement
-        )
+        return "%s(%s+0x%016x)" % (self.__class__.__name__, self.base_address,
+                                   self.displacement)
 
     def __rsub__(self, other):
         """
@@ -301,10 +281,8 @@ class Address(object):
         if isinstance(other, (Address, InstructionAddress)):
 
             if self.base_address != other.base_address:
-                raise MicroprobeCodeGenerationError(
-                    "I can not sub '%s' "
-                    "and '%s'" % (self, other)
-                )
+                raise MicroprobeCodeGenerationError("I can not sub '%s' "
+                                                    "and '%s'" % (self, other))
 
             return other.displacement - self.displacement
 
@@ -313,14 +291,12 @@ class Address(object):
         else:
             raise NotImplementedError(
                 "Substraction not implemented for %s and %s "
-                "objects" % (self.__class__, other.__class__)
-            )
+                "objects" % (self.__class__, other.__class__))
 
     def __str__(self):
         """ """
-        return "%s(%s+0x%016x)" % (
-            self.__class__.__name__, self.base_address, self.displacement
-        )
+        return "%s(%s+0x%016x)" % (self.__class__.__name__, self.base_address,
+                                   self.displacement)
 
     def __sub__(self, other):
         """
@@ -332,10 +308,8 @@ class Address(object):
         if isinstance(other, self.__class__):
 
             if self.base_address != other.base_address:
-                raise MicroprobeCodeGenerationError(
-                    "I can not sub '%s' "
-                    "and '%s'" % (self, other)
-                )
+                raise MicroprobeCodeGenerationError("I can not sub '%s' "
+                                                    "and '%s'" % (self, other))
 
             return self.displacement - other.displacement
 
@@ -359,10 +333,8 @@ class InstructionAddress(Address):
         :param instruction:  (Default value = None)
 
         """
-        super(InstructionAddress, self).__init__(
-            base_address=base_address,
-            displacement=displacement
-        )
+        super(InstructionAddress, self).__init__(base_address=base_address,
+                                                 displacement=displacement)
         self._instruction = instruction
 
     @property
@@ -472,11 +444,8 @@ class MemoryValue(object):
 
     def _check_cmp(self, other):
         if not isinstance(other, self.__class__):
-            raise NotImplementedError(
-                "%s != %s" % (
-                    other.__class__, self.__class__
-                )
-            )
+            raise NotImplementedError("%s != %s" %
+                                      (other.__class__, self.__class__))
 
     def __eq__(self, other):
         """x.__eq__(y) <==> x==y"""
@@ -536,14 +505,12 @@ class MemoryValue(object):
 
     def __repr__(self):
         """ """
-        return "%s(%s, Value:%s, Length:%d)" % (
-            self.__class__.__name__, self._address,
-            hex(self._value), self._length
-        )
+        return "%s(%s, Value:%s, Length:%d)" % (self.__class__.__name__,
+                                                self._address, hex(
+                                                    self._value), self._length)
 
     def __str__(self):
         """ """
-        return "%s(%s, Value:%s, Length:%d)" % (
-            self.__class__.__name__, self._address,
-            hex(self._value), self._length
-        )
+        return "%s(%s, Value:%s, Length:%d)" % (self.__class__.__name__,
+                                                self._address, hex(
+                                                    self._value), self._length)

--- a/src/microprobe/code/bbl.py
+++ b/src/microprobe/code/bbl.py
@@ -29,7 +29,6 @@ from microprobe.exceptions import MicroprobeCodeGenerationError, \
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import Progress
 
-
 # Constants
 LOG = get_logger(__name__)
 __all__ = ["Bbl", "replicate_bbls"]
@@ -65,9 +64,8 @@ class Bbl(object):
 
         """
         if size < 1:
-            raise MicroprobeValueError(
-                "I can not create a Bbl with %d size" % size
-            )
+            raise MicroprobeValueError("I can not create a Bbl with %d size" %
+                                       size)
 
         if instructions is None:
             instructions = []
@@ -193,10 +191,8 @@ class Bbl(object):
 
         idx = self._index(instr)
         if idx < 0:
-            raise MicroprobeCodeGenerationError(
-                "Instruction not found "
-                "in the basic block"
-            )
+            raise MicroprobeCodeGenerationError("Instruction not found "
+                                                "in the basic block")
         self._instrs[idx] = new_instr
 
     def remove_instructions_from(self, instr):
@@ -264,8 +260,7 @@ class Bbl(object):
             # assert idx_before == -1 and idx_after > -1
 
             if not any(
-                    self._instrs[idx_after + 1:idx_after + 1 + len(instrs)]
-            ):
+                    self._instrs[idx_after + 1:idx_after + 1 + len(instrs)]):
 
                 self._instrs[idx_after + 1:idx_after + 1 + len(instrs)] = \
                     instrs
@@ -279,12 +274,9 @@ class Bbl(object):
                 self._check_size(extra=len(instrs))
                 self._instrs[(idx_after) + 1:len(instrs)] = instrs
                 self._pointer += len(instrs)
-                self._instdic = dict(
-                    [
-                        (v, idx)
-                        for idx, v in enumerate(self._instrs) if v is not None
-                    ]
-                )
+                self._instdic = dict([(v, idx)
+                                      for idx, v in enumerate(self._instrs)
+                                      if v is not None])
 
     def _increase(self, num):
         """Increases the basic block size by the number specified.

--- a/src/microprobe/code/benchmark.py
+++ b/src/microprobe/code/benchmark.py
@@ -28,8 +28,9 @@ from microprobe.utils.misc import OrderedDict
 
 # Constants
 LOG = get_logger(__name__)
-__all__ = ["BuildingBlock", "Benchmark",
-           "MultiThreadedBenchmark", "benchmark_factory"]
+__all__ = [
+    "BuildingBlock", "Benchmark", "MultiThreadedBenchmark", "benchmark_factory"
+]
 
 
 # Functions
@@ -167,10 +168,8 @@ class Benchmark(BuildingBlock):
         """
         LOG.debug("Add Init")
         for init in inits:
-            LOG.debug(
-                "NEW INIT INSTRUCTION: %s (prepend: %s)",
-                init.assembly(), prepend
-            )
+            LOG.debug("NEW INIT INSTRUCTION: %s (prepend: %s)",
+                      init.assembly(), prepend)
 
         if not prepend:
             self._init = self._init + inits
@@ -237,21 +236,17 @@ class Benchmark(BuildingBlock):
         if var.name in self._global_vars:
 
             var2 = self._global_vars[var.name]
-            if (var.value == var2.value and
-                    var.address == var2.address and
-                    var.address is not None and
-                    MICROPROBE_RC['safe_bin']):
-                LOG.warning(
-                    "Variable: '%s' registered multiple times!", var.name
-                )
+            if (var.value == var2.value and var.address == var2.address
+                    and var.address is not None and MICROPROBE_RC['safe_bin']):
+                LOG.warning("Variable: '%s' registered multiple times!",
+                            var.name)
 
                 return
 
             LOG.critical("Registered variables: %s",
                          list(self._global_vars.keys()))
             raise MicroprobeCodeGenerationError(
-                "Variable already registered: %s" % (var.name)
-            )
+                "Variable already registered: %s" % (var.name))
 
         self._global_vars[var.name] = var
 
@@ -271,10 +266,8 @@ class Benchmark(BuildingBlock):
             address_ok = False
 
             while not address_ok:
-                var_address = Address(
-                    base_address="data",
-                    displacement=self._vardisplacement
-                )
+                var_address = Address(base_address="data",
+                                      displacement=self._vardisplacement)
 
                 LOG.debug("Address before alignment: %s", var_address)
 
@@ -288,14 +281,13 @@ class Benchmark(BuildingBlock):
                 if (var_address.displacement +
                         context.data_segment) % align != 0:
                     # alignment needed
-                    var_address += align - ((
-                        var_address.displacement+context.data_segment) % align
-                    )
+                    var_address += align - (
+                        (var_address.displacement + context.data_segment) %
+                        align)
 
                 LOG.debug("Address after alignment: %s", var_address)
-                LOG.debug(
-                    "Current var displacement: %x", self._vardisplacement
-                )
+                LOG.debug("Current var displacement: %x",
+                          self._vardisplacement)
 
                 var.set_address(var_address)
                 over = self._check_variable_overlap(var)
@@ -303,8 +295,7 @@ class Benchmark(BuildingBlock):
                 if over is not None:
                     self._vardisplacement = max(
                         self._vardisplacement,
-                        over.address.displacement + over.size
-                    )
+                        over.address.displacement + over.size)
                     continue
 
                 address_ok = True
@@ -318,10 +309,8 @@ class Benchmark(BuildingBlock):
         over = self._check_variable_overlap(var)
         if over is not None:
             raise MicroprobeCodeGenerationError(
-                "Variable '%s' overlaps with variable '%s'" % (
-                    var.name, over.name
-                )
-            )
+                "Variable '%s' overlaps with variable '%s'" %
+                (var.name, over.name))
 
     def _check_variable_overlap(self, var):
 
@@ -411,8 +400,7 @@ class Benchmark(BuildingBlock):
             else:
                 raise MicroprobeCodeGenerationError(
                     "Attempt to inserst instruction in a position that it is"
-                    " not possible"
-                )
+                    " not possible")
 
     @property
     def code_size(self):
@@ -435,13 +423,13 @@ class Benchmark(BuildingBlock):
                     labels.append(instr.label.upper())
 
         labels += [
-            instr.label.upper()
-            for instr in self._fini if instr.label is not None
+            instr.label.upper() for instr in self._fini
+            if instr.label is not None
         ]
 
         labels += [
-            instr.label.upper()
-            for instr in self._init if instr.label is not None
+            instr.label.upper() for instr in self._init
+            if instr.label is not None
         ]
 
         return labels
@@ -452,8 +440,7 @@ class Benchmark(BuildingBlock):
         if not 1 <= idx <= self._num_threads + 1:
             raise MicroprobeCodeGenerationError(
                 "Unknown thread id: %d (min: 1, max: %d)" %
-                (idx, self._num_threads + 1)
-            )
+                (idx, self._num_threads + 1))
 
 
 class MultiThreadedBenchmark(Benchmark):
@@ -468,5 +455,5 @@ class MultiThreadedBenchmark(Benchmark):
         self._current_thread = 1
 
     def __getattr__(self, attribute_name):
-        return self._threads[
-            self._current_thread].__getattribute__(attribute_name)
+        return self._threads[self._current_thread].__getattribute__(
+            attribute_name)

--- a/src/microprobe/code/cfg.py
+++ b/src/microprobe/code/cfg.py
@@ -16,11 +16,16 @@
 """
 
 # Futures
-from __future__ import absolute_import
+from __future__ import absolute_import, annotations
+from typing import TYPE_CHECKING, List, Tuple
 
 # Own modules
-import microprobe.code.bbl
+from microprobe.code.bbl import Bbl
 from microprobe.utils.logger import get_logger
+
+# Type hinting
+if TYPE_CHECKING:
+    from microprobe.code.ins import Instruction
 
 # Constants
 LOG = get_logger(__name__)
@@ -31,18 +36,21 @@ __all__ = ["Cfg"]
 # Classes
 
 
-class Cfg(object):
+class Cfg:
     """Class to represent the control flow graph of a building block."""
 
     def __init__(self):
         """ """
-        self._cfg_nodes = []
-        self._cfg_edges = []
+        self._cfg_nodes: List[Bbl] = []
+        self._cfg_edges: List[Tuple[int, int]] = []
         self._idx = 0
         self._last_bbl = None
         self._first_bbl = None
 
-    def add_bbl(self, bbl=None, size=1, instructions=None):
+    def add_bbl(self,
+                bbl: Bbl | None = None,
+                size: int = 1,
+                instructions: List[Instruction] | None = None):
         """Adds a basic block to the control flow graph of the specified size.
 
         :param bbl: Basic block to add (if none, one is created)
@@ -57,10 +65,9 @@ class Cfg(object):
         if bbl is None:
 
             if instructions is not None:
-                bbl = microprobe.code.bbl.Bbl(len(instructions),
-                                              instructions=instructions)
+                bbl = Bbl(len(instructions), instructions=instructions)
             else:
-                bbl = microprobe.code.bbl.Bbl(size)
+                bbl = Bbl(size)
 
         self._cfg_nodes.append(bbl)
         self._cfg_edges.append((self._idx, self._idx + 1))
@@ -72,7 +79,7 @@ class Cfg(object):
         self._idx += 1
         return bbl
 
-    def add_bbls(self, bbls):
+    def add_bbls(self, bbls: List[Bbl]):
         """Adds a list of basic blocks to the control flow graph.
 
         :param bbls: Lists of basic blocks to add.
@@ -88,7 +95,7 @@ class Cfg(object):
         (:class:`~.list` of :class:`~.Bbl`)."""
         return self._cfg_nodes[:]
 
-    def index(self, instr):
+    def index(self, instr: Instruction):
         """Returns index of the basic block containing the given instruction.
 
         :param instr: Instruction to look for
@@ -104,7 +111,7 @@ class Cfg(object):
             return -1
         return rlist[0]
 
-    def get_bbl(self, index):
+    def get_bbl(self, index: int):
         """Returns the basic block at the specified index
 
         :param index: Index of the bbl

--- a/src/microprobe/code/cfg.py
+++ b/src/microprobe/code/cfg.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 import microprobe.code.bbl
 from microprobe.utils.logger import get_logger
 
-
 # Constants
 LOG = get_logger(__name__)
 __all__ = ["Cfg"]
@@ -58,10 +57,8 @@ class Cfg(object):
         if bbl is None:
 
             if instructions is not None:
-                bbl = microprobe.code.bbl.Bbl(
-                    len(instructions),
-                    instructions=instructions
-                )
+                bbl = microprobe.code.bbl.Bbl(len(instructions),
+                                              instructions=instructions)
             else:
                 bbl = microprobe.code.bbl.Bbl(size)
 
@@ -99,8 +96,7 @@ class Cfg(object):
 
         """
         rlist = [
-            idx
-            for idx, bbl in enumerate(self.bbls)
+            idx for idx, bbl in enumerate(self.bbls)
             if bbl.get_instruction_index(instr) >= 0
         ]
 

--- a/src/microprobe/code/context.py
+++ b/src/microprobe/code/context.py
@@ -50,14 +50,12 @@ class Context(object):  # pylint: disable=too-many-public-methods
 
     """
 
-    def __init__(
-            self,
-            default_context: Context | None = None,
-            code_segment: int | None = None,
-            data_segment: int | None = None,
-            symbolic: bool = True,
-            absolute: bool = False
-    ):
+    def __init__(self,
+                 default_context: Context | None = None,
+                 code_segment: int | None = None,
+                 data_segment: int | None = None,
+                 symbolic: bool = True,
+                 absolute: bool = False):
         """
 
         :param default_context:  (Default value = None)
@@ -69,12 +67,10 @@ class Context(object):  # pylint: disable=too-many-public-methods
 
         self._reserved_registers: Dict[str, Register] = RejectingDict()
 
-        self._register_values: Dict[
-            Register, int | float | Address | str | None
-        ] = {}
-        self._value_registers: Dict[
-            int | float | Address | str, List[Register]
-        ] = {}
+        self._register_values: Dict[Register,
+                                    int | float | Address | str | None] = {}
+        self._value_registers: Dict[int | float | Address | str,
+                                    List[Register]] = {}
         self._memory_values: Dict[Address, MemoryValue] = {}
         self._value_memorys: Dict[MemoryValue, List[MemoryValue]] = {}
 
@@ -95,8 +91,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
 
         # pylint: disable=protected-access
         newcontext._reserved_registers = smart_copy_dict(
-            self._reserved_registers
-        )
+            self._reserved_registers)
         newcontext._register_values = smart_copy_dict(self._register_values)
         newcontext._value_registers = smart_copy_dict(self._value_registers)
         newcontext._memory_values = smart_copy_dict(self._memory_values)
@@ -134,10 +129,8 @@ class Context(object):  # pylint: disable=too-many-public-methods
         for reg in rregs:
             del self._reserved_registers[reg.name]
 
-    def set_register_value(
-            self,
-            register: Register, value: int | float | Address | str
-    ):
+    def set_register_value(self, register: Register,
+                           value: int | float | Address | str):
         """Set the provided register to the specified value.
 
         :param register: Register to set
@@ -151,9 +144,10 @@ class Context(object):  # pylint: disable=too-many-public-methods
         LOG.debug("Setting %s to %s", register.name, value)
 
         assert isinstance(
-            value, tuple(list(six.integer_types) +
-                         [float, Address, InstructionAddress, str])
-        ), type(value)
+            value,
+            tuple(
+                list(six.integer_types) +
+                [float, Address, InstructionAddress, str])), type(value)
 
         if isinstance(value, str):
             assert len(value.split("_")) == 2
@@ -194,8 +188,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
 
             possible_regs.append((reg, val))
 
-        possible_regs = sorted(possible_regs,
-                               key=lambda x: abs(x[1] - value))
+        possible_regs = sorted(possible_regs, key=lambda x: abs(x[1] - value))
         if possible_regs:
             return possible_regs[0]
 
@@ -223,9 +216,9 @@ class Context(object):  # pylint: disable=too-many-public-methods
                     Address(base_address=address.base_address):
                 possible_regs.append((reg, value))
 
-        possible_regs = sorted(possible_regs,
-                               key=lambda x: abs(x[1].displacement -
-                                                 address.displacement))
+        possible_regs = sorted(
+            possible_regs,
+            key=lambda x: abs(x[1].displacement - address.displacement))
         if possible_regs:
             return possible_regs[0]
 
@@ -263,9 +256,10 @@ class Context(object):  # pylint: disable=too-many-public-methods
         if not isinstance(value, str):
             possible_regs = sorted(possible_regs, key=lambda x: abs(x - value))
         else:
-            possible_regs = sorted(possible_regs,
-                                   key=lambda x: abs(int(x.split("_")[0]) -
-                                                     int(value.split("_")[0])))
+            possible_regs = sorted(
+                possible_regs,
+                key=lambda x: abs(
+                    int(x.split("_")[0]) - int(value.split("_")[0])))
 
         if possible_regs:
             return possible_regs[0]
@@ -301,8 +295,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
             return None
 
         register = [
-            reg for reg in self._register_values
-            if reg.name == register_name
+            reg for reg in self._register_values if reg.name == register_name
         ][0]
 
         return self._register_values.get(register, None)
@@ -353,10 +346,8 @@ class Context(object):  # pylint: disable=too-many-public-methods
             if mem_value not in self._value_memorys[mem_value.value]:
 
                 self._value_memorys[mem_value.value].append(mem_value)
-                LOG.debug(
-                    "Values inv %s: %s", mem_value.value,
-                    self._value_memorys[mem_value.value]
-                )
+                LOG.debug("Values inv %s: %s", mem_value.value,
+                          self._value_memorys[mem_value.value])
 
             else:
                 LOG.debug("Already in inv dictionary")
@@ -397,8 +388,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
         LOG.debug("Start unset address: %s (length: %s)", address, length)
 
         possible_addresses = [
-            addr
-            for addr in self._memory_values
+            addr for addr in self._memory_values
             if addr.base_address == address.base_address
         ]
 
@@ -410,10 +400,8 @@ class Context(object):  # pylint: disable=too-many-public-methods
             diff2 = address - paddr
             length2 = self._memory_values[paddr].length
 
-            if (
-                    (diff >= 0 and diff < length) or
-                    (diff2 >= 0 and diff2 < length2)
-            ):
+            if ((diff >= 0 and diff < length)
+                    or (diff2 >= 0 and diff2 < length2)):
 
                 LOG.debug("Address overlap: %s", paddr)
                 mem_value = self._memory_values.pop(paddr)
@@ -432,8 +420,10 @@ class Context(object):  # pylint: disable=too-many-public-methods
         :type value: :class:`~.bool`
 
         """
-        return value in list([elem for elem in self._value_registers.keys()
-                             if type(elem) == type(value)])
+        return value in list([
+            elem for elem in self._value_registers.keys()
+            if type(elem) == type(value)
+        ])
 
     def registers_get_value(self, value: int | float | Address | str):
         """Gets a list of registers containing the specified value.
@@ -566,10 +556,8 @@ class Context(object):  # pylint: disable=too-many-public-methods
             mstr.append("Idx:\t%s\tRaw Value:\t%s" % (key, value))
 
         mstr.append("Registers values inverted:")
-        for key, value in sorted([
-                    (str(k), str(v)) for k, v
-                    in self._value_registers.items()
-                ]):
+        for key, value in sorted([(str(k), str(v))
+                                  for k, v in self._value_registers.items()]):
             mstr.append("Idx:\t%s\tValue:\t%s" % (key, value))
 
         mstr.append("Memory values:")

--- a/src/microprobe/code/context.py
+++ b/src/microprobe/code/context.py
@@ -29,7 +29,7 @@ from microprobe.code.address import Address, InstructionAddress
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import RejectingDict, smart_copy_dict
 
-# Type hints
+# Type hinting
 if TYPE_CHECKING:
     from microprobe.target.isa.register import Register
     from microprobe.code.address import MemoryValue

--- a/src/microprobe/code/ins.py
+++ b/src/microprobe/code/ins.py
@@ -454,17 +454,28 @@ class InstructionOperandValue(Pickable):
 
         return self._operand_descriptor.type.access(self.value)
 
-    def __getattr__(self, name):
+    @property
+    def type(self):
+        """Type of the operand descriptor (:class:`~.Operand`)"""
+        return self._operand_descriptor._type
+
+    @property
+    def is_input(self):
+        """Is input flag (:class:`~.bool`) """
+        return self._operand_descriptor._is_input
+
+    @property
+    def is_output(self):
+        """Is output flag (:class:`~.bool`) """
+        return self._operand_descriptor._is_output
+
+    def set_type(self, new_type):
         """
 
-        :param name:
+        :param new_type:
 
         """
-        try:
-            return self._operand_descriptor.__getattribute__(name)
-        except AttributeError:
-            raise AttributeError("'%s' object has no attribute '%s'" %
-                                 (self.__class__.__name__, name))
+        self._operand_descriptor._type = new_type
 
     def __repr__(self):
         """ """

--- a/src/microprobe/code/ins.py
+++ b/src/microprobe/code/ins.py
@@ -39,7 +39,6 @@ from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import OrderedDict, \
     Pickable, RejectingDict, RejectingOrderedDict
 
-
 # Constants
 LOG = get_logger(__name__)
 __all__ = [
@@ -81,10 +80,10 @@ def instruction_to_definition(instr):
         asm = asmfmt % int(instr.binary(), 2)
         comments = [instr.assembly()] + instr.comments
 
-    return MicroprobeInstructionDefinition(instr.architecture_type, [
-        operand.value for operand in instr.operands()
-    ], label, instr.address, asm,
-        instr.decorators, comments)
+    return MicroprobeInstructionDefinition(
+        instr.architecture_type,
+        [operand.value for operand in instr.operands()], label, instr.address,
+        asm, instr.decorators, comments)
 
 
 def instruction_from_definition(definition, fix_relative=True):
@@ -100,8 +99,9 @@ def instruction_from_definition(definition, fix_relative=True):
     """
 
     ninstr = Instruction()
-    instruction_set_def_properties(
-        ninstr, definition, fix_relative=fix_relative)
+    instruction_set_def_properties(ninstr,
+                                   definition,
+                                   fix_relative=fix_relative)
     return ninstr
 
 
@@ -167,9 +167,9 @@ def instruction_set_def_properties(instr,
         for idx, operand in enumerate(operands):
             LOG.debug("Fixing operands: %s", operand)
 
-            if (isinstance(operand, six.integer_types) and
-                    instr.operands()[idx].type.address_relative and
-                    fix_relative):
+            if (isinstance(operand, six.integer_types)
+                    and instr.operands()[idx].type.address_relative
+                    and fix_relative):
                 LOG.debug("Hardcoded displacement")
                 if instr.branch:
 
@@ -202,15 +202,13 @@ def instruction_set_def_properties(instr,
                 for var in building_block.registered_global_vars():
                     if operand.startswith(var.name) and "@" not in operand:
                         if operand.replace(var.name, "") != "":
-                            displacement = int(
-                                operand.replace(var.name, ""),
-                                base=0)
+                            displacement = int(operand.replace(var.name, ""),
+                                               base=0)
                             operand = var.name
                             break
 
                 possible_vars = [
-                    var
-                    for var in building_block.registered_global_vars()
+                    var for var in building_block.registered_global_vars()
                     if var.name == operand
                 ]
 
@@ -268,8 +266,8 @@ def instruction_set_def_properties(instr,
             instr.set_operands(fixed_operands)
         else:
             for operand, value in zip(instr.operands(), fixed_operands):
-                if (isinstance(operand.type, OperandImmRange) and
-                        "@" in value):
+                if (isinstance(operand.type, OperandImmRange)
+                        and "@" in value):
                     operand.set_value(value, check=False)
                 else:
                     operand.set_value(value)
@@ -287,8 +285,8 @@ def instruction_set_def_properties(instr,
                 decorator_value = [decorator_value]
             decorator_value = ["0x%016X" % elem for elem in decorator_value]
 
-        instr.add_comment("Decorator: %s = %s" % (decorator_key,
-                                                  decorator_value))
+        instr.add_comment("Decorator: %s = %s" %
+                          (decorator_key, decorator_value))
         instr.add_decorator(decorator_key, decorator_value)
 
     for register_name in allowed_registers:
@@ -560,8 +558,7 @@ class InstructionMemoryOperandValue(Pickable):
         """Variable length value(:class:`~.bool`)."""
 
         operand_values = [
-            operand
-            for operand in self._length_values
+            operand for operand in self._length_values
             if (isinstance(operand, InstructionOperandValue) or isinstance(
                 operand, OperandDescriptor) or isinstance(operand, tuple))
         ]
@@ -572,8 +569,9 @@ class InstructionMemoryOperandValue(Pickable):
                     return True
                 elif len(list(operand.type.values())) > 1:
                     return True
-                elif not isinstance(list(operand.type.values())[0],
-                                    tuple([str] + list(six.integer_types))):
+                elif not isinstance(
+                        list(operand.type.values())[0],
+                        tuple([str] + list(six.integer_types))):
                     return True
 
         return False
@@ -609,28 +607,25 @@ class InstructionMemoryOperandValue(Pickable):
             return
 
         operand_values = [
-            operand
-            for operand in self._length_values
+            operand for operand in self._length_values
             if isinstance(operand, InstructionOperandValue)
         ]
 
         operand_constants = [
-            operand
-            for operand in self._length_values
-            if (not isinstance(operand, InstructionOperandValue) and
-                not isinstance(operand, tuple) and not isinstance(
-                    operand, OperandDescriptor))
+            operand for operand in self._length_values
+            if (not isinstance(operand, InstructionOperandValue)
+                and not isinstance(operand, tuple)
+                and not isinstance(operand, OperandDescriptor))
         ]
 
         operand_register_const = [
-            operand
-            for operand in self._length_values
+            operand for operand in self._length_values
             if isinstance(operand, OperandDescriptor)
         ]
 
         operand_special = [
-            operand
-            for operand in self._length_values if isinstance(operand, tuple)
+            operand for operand in self._length_values
+            if isinstance(operand, tuple)
         ]
 
         operand_registers_diff = [
@@ -665,13 +660,12 @@ class InstructionMemoryOperandValue(Pickable):
 
                     # Check if the operand is negated
                     preindex = [
-                        lidx
-                        for lidx, elem in enumerate(self._length_values)
+                        lidx for lidx, elem in enumerate(self._length_values)
                         if elem == operand
                     ][0]
 
-                    if (preindex > 0 and self._length_values[
-                            preindex - 1] == "-"):
+                    if (preindex > 0
+                            and self._length_values[preindex - 1] == "-"):
                         LOG.debug("Negated Immediate operand")
                         operand_lengths[operand] = [
                             elem * (-1) for elem in operand.type.values()
@@ -762,8 +756,8 @@ class InstructionMemoryOperandValue(Pickable):
 
                 for val2 in reg2_vals:
 
-                    if (val2 in context.reserved_registers and
-                            not allow_reserved):
+                    if (val2 in context.reserved_registers
+                            and not allow_reserved):
                         LOG.debug("%s in reserved registers", val2)
                         continue
 
@@ -785,8 +779,8 @@ class InstructionMemoryOperandValue(Pickable):
                         skip = False
 
                         for reserved in context.reserved_registers:
-                            if (int(reserved.representation) > ival2 and
-                                    int(reserved.representation) < ival1):
+                            if (int(reserved.representation) > ival2
+                                    and int(reserved.representation) < ival1):
                                 skip = True
                                 break
 
@@ -875,8 +869,7 @@ class InstructionMemoryOperandValue(Pickable):
 
                         # TODO: Maximum length is hard-coded to 1024 bytes
                         for elem in range(
-                                0,
-                                min((2**length[0].type.size) - 1, 1024),
+                                0, min((2**length[0].type.size) - 1, 1024),
                                 ceil_value):
                             newlengths[(length[0], elem)] = elem
 
@@ -903,15 +896,15 @@ class InstructionMemoryOperandValue(Pickable):
 
                             elif isinstance(length, tuple):
 
-                                if (isinstance(length[0], Register) and
-                                        isinstance(length[1], Register)):
+                                if (isinstance(length[0], Register)
+                                        and isinstance(length[1], Register)):
 
                                     if lengths[length] > maxvalue:
                                         lengths_to_remove.append(length)
 
-                                elif (isinstance(length[0], Register) and
-                                      isinstance(length[1],
-                                                 six.integer_types)):
+                                elif (isinstance(length[0], Register)
+                                      and isinstance(length[1],
+                                                     six.integer_types)):
 
                                     if lengths[length] > maxvalue:
                                         # TODO: Assuming that min value is
@@ -1065,8 +1058,7 @@ class InstructionMemoryOperandValue(Pickable):
         self._compute_possible_lengths(context)
 
         operand_values = [
-            key
-            for key in self._possible_lengths
+            key for key in self._possible_lengths
             if self._possible_lengths[key] == length
         ]
 
@@ -1077,18 +1069,18 @@ class InstructionMemoryOperandValue(Pickable):
 
         operands = []
         for operand in self._length_values:
-            if isinstance(operand, (InstructionOperandValue,
-                                    OperandDescriptor)):
+            if isinstance(operand,
+                          (InstructionOperandValue, OperandDescriptor)):
                 operands.append(operand)
             elif isinstance(operand, tuple):
                 if operand[1] == "MASK":
                     operands.append(operand[0])
-                elif (isinstance(operand[1], InstructionOperandValue) and
-                      isinstance(operand[2], InstructionOperandValue)):
+                elif (isinstance(operand[1], InstructionOperandValue)
+                      and isinstance(operand[2], InstructionOperandValue)):
                     operands.append(operand[1])
                     operands.append(operand[2])
-                elif (operand[1] == "REGMAX" and
-                      isinstance(operand[2], InstructionOperandValue)):
+                elif (operand[1] == "REGMAX"
+                      and isinstance(operand[2], InstructionOperandValue)):
                     # operands.append(max(operand[2].type.values()))
                     operands.append(operand[2])
                 else:
@@ -1125,8 +1117,8 @@ class InstructionMemoryOperandValue(Pickable):
         # TODO: Why this check?
         if isinstance(operand_values, tuple):
 
-            if (isinstance(operand_values[0], Register) and
-                    isinstance(operand_values[1], Register)):
+            if (isinstance(operand_values[0], Register)
+                    and isinstance(operand_values[1], Register)):
 
                 operand_values = [operand_values[0], operand_values[1]]
 
@@ -1164,8 +1156,8 @@ class InstructionMemoryOperandValue(Pickable):
 
                 operand.set_value(register)
 
-                if (value is not None and
-                        context.get_register_value(register) != value):
+                if (value is not None
+                        and context.get_register_value(register) != value):
 
                     LOG.debug("Context: %s", context.dump())
                     LOG.debug("Register used: %s", register)
@@ -1234,18 +1226,18 @@ class InstructionMemoryOperandValue(Pickable):
                 LOG.debug("Base operand %d: %s", idx, operand)
                 base_operand = operand
 
-            if (operand.descriptor.type.address_index and
-                    index_operand_reg is None):
+            if (operand.descriptor.type.address_index
+                    and index_operand_reg is None):
                 LOG.debug("Index operand %d: %s", idx, operand)
                 index_operand_reg = operand
 
-            if (operand.descriptor.type.address_immediate and
-                    index_operand_imm is None):
+            if (operand.descriptor.type.address_immediate
+                    and index_operand_imm is None):
                 LOG.debug("Immediate operand %d: %s", idx, operand)
                 index_operand_imm = operand
 
-            if (operand.descriptor.type.address_relative and
-                    relative_operand is None):
+            if (operand.descriptor.type.address_relative
+                    and relative_operand is None):
                 LOG.debug("Relative operand %d: %s", idx, operand)
                 relative_operand = operand
 
@@ -1268,14 +1260,12 @@ class InstructionMemoryOperandValue(Pickable):
         if base_operand is None:
             raise MicroprobeCodeGenerationError(
                 "I do not know how to generate "
-                "this address: %s (no base operand)" % address
-            )
+                "this address: %s (no base operand)" % address)
 
         if not base_operand.descriptor.is_input:
             raise MicroprobeCodeGenerationError(
                 "I do not know how to generate "
-                "this address: %s (no base operand input)" % address
-            )
+                "this address: %s (no base operand input)" % address)
 
         fast_path = False
         if context.register_has_value(address):
@@ -1301,8 +1291,7 @@ class InstructionMemoryOperandValue(Pickable):
                 if context.register_has_value(0):
 
                     register_zero_list = [
-                        reg for reg
-                        in context.registers_get_value(0)
+                        reg for reg in context.registers_get_value(0)
                         if reg in list(index_operand_reg.type.values())
                     ]
 
@@ -1310,8 +1299,8 @@ class InstructionMemoryOperandValue(Pickable):
                     raise MicroprobeCodeGenerationError(
                         "I do not know how to generate this address: %s. "
                         "One of the following registers should be set to zero:"
-                        " %s" % (address,
-                                 list(index_operand_reg.type.values())))
+                        " %s" %
+                        (address, list(index_operand_reg.type.values())))
 
                 index_operand_reg.set_value(register_zero_list[0])
 
@@ -1355,14 +1344,13 @@ class InstructionMemoryOperandValue(Pickable):
             closest_address = possible_base_regs[0][1]
 
             for reg, paddress in possible_base_regs[1:]:
-                if index - paddress.displacement > 0 and (abs(
-                        index - paddress.displacement) < abs(closest_index)):
+                if index - paddress.displacement > 0 and (
+                        abs(index - paddress.displacement)
+                        < abs(closest_index)):
 
-                    if ((index_operand_imm is None) and
-                            not context.register_has_value(
-                        index -
-                        paddress.displacement
-                    )):
+                    if ((index_operand_imm is None)
+                            and not context.register_has_value(
+                                index - paddress.displacement)):
                         continue
 
                     closest_index = index - paddress.displacement
@@ -1384,13 +1372,13 @@ class InstructionMemoryOperandValue(Pickable):
         #    assert address == generated_address
 
         set_index = False
-        if (index_operand_imm is not None and not set_index and
-                generated_address != address):
+        if (index_operand_imm is not None and not set_index
+                and generated_address != address):
 
             LOG.debug("The instruction has immediate operand, and the "
                       "generated address still needs some extra displacement")
-            assert (index_operand_imm.descriptor.is_input and
-                    not index_operand_imm.descriptor.is_output)
+            assert (index_operand_imm.descriptor.is_input
+                    and not index_operand_imm.descriptor.is_output)
 
             try:
                 LOG.debug("Setting immediate displacement")
@@ -1404,13 +1392,13 @@ class InstructionMemoryOperandValue(Pickable):
                     "I do not know how to generate that address. Index "
                     "register not set.")
 
-        if (index_operand_reg is not None and not set_index and
-                generated_address != address):
+        if (index_operand_reg is not None and not set_index
+                and generated_address != address):
 
             LOG.debug("The instruction has index register operand, and the "
                       "generated address still needs some extra displacement")
-            assert (index_operand_reg.descriptor.is_input and
-                    not index_operand_reg.descriptor.is_output)
+            assert (index_operand_reg.descriptor.is_input
+                    and not index_operand_reg.descriptor.is_output)
 
             if not context.register_has_value(index):
                 LOG.debug("Unable to generate the address with the current "
@@ -1420,8 +1408,10 @@ class InstructionMemoryOperandValue(Pickable):
                     "register not set. Change the generation policy.")
 
             registers_index = context.registers_get_value(index)
-            registers_index = [reg for reg in registers_index
-                               if reg in list(index_operand_reg.type.values())]
+            registers_index = [
+                reg for reg in registers_index
+                if reg in list(index_operand_reg.type.values())
+            ]
 
             if len(registers_index) == 0:
                 LOG.debug("Unable to generate the address with the current "
@@ -1436,16 +1426,16 @@ class InstructionMemoryOperandValue(Pickable):
             generated_address += index
             LOG.debug("Using register: %s", register_index.name)
 
-        if (index_operand_imm is not None and set_index and
-                generated_address == address and
-                index_operand_imm.value is None):
+        if (index_operand_imm is not None and set_index
+                and generated_address == address
+                and index_operand_imm.value is None):
 
             LOG.debug("Setting index immediate operand to zero")
             index_operand_imm.set_value(0)
 
-        if (index_operand_reg is not None and set_index and
-                generated_address == address and
-                index_operand_reg.value is None):
+        if (index_operand_reg is not None and set_index
+                and generated_address == address
+                and index_operand_reg.value is None):
 
             LOG.debug("Setting index register operand to zero")
             register_zero = context.registers_get_value(0)[0]
@@ -1497,9 +1487,8 @@ class InstructionMemoryOperandValue(Pickable):
                 return
 
         # Only fixing relative operands.
-        if (len(self.operands) == 1 and
-                self.operands[0].type.address_relative and
-                isinstance(self.operands[0].value, InstructionAddress)):
+        if (len(self.operands) == 1 and self.operands[0].type.address_relative
+                and isinstance(self.operands[0].value, InstructionAddress)):
             self._address = self.operands[0].value
 
         if context is not None:
@@ -1517,8 +1506,8 @@ class InstructionMemoryOperandValue(Pickable):
 
         if self._forbidden_max is None and self._forbidden_min is None:
             return
-        elif (self._forbidden_max is not None and
-              self._forbidden_min is not None):
+        elif (self._forbidden_max is not None
+              and self._forbidden_min is not None):
 
             assert self._address > self._forbidden_max or \
                 (self._address + self._length) < self._forbidden_min
@@ -1635,10 +1624,11 @@ class Instruction(Pickable):
                     # force it to be address base (is this generic?)
                     # needed for POWERPC branches to CTR or LR
 
-                    operand_value.descriptor.set_type(OperandConstReg(
-                        operand_value.type.name, operand_value.type.
-                        description, list(operand_value.type.values())[
-                            0], True, False, False, False))
+                    operand_value.descriptor.set_type(
+                        OperandConstReg(operand_value.type.name,
+                                        operand_value.type.description,
+                                        list(operand_value.type.values())[0],
+                                        True, False, False, False))
                     operand_value.descriptor.set_type(operand_value.type)
 
                     operand_value.set_value(operand_value.type.values()[0])
@@ -1679,15 +1669,16 @@ class Instruction(Pickable):
                         raise NotImplementedError
 
                     # assert operand_type == length_value.type
-                    length_values.append((operand_type, length_value_a,
-                                          length_value_b))
+                    length_values.append(
+                        (operand_type, length_value_a, length_value_b))
 
                 else:
 
                     length_values.append(operand_type)
 
-            self._mem_operands.append(InstructionMemoryOperandValue(
-                mem_operand_descr, operand_values, length_values))
+            self._mem_operands.append(
+                InstructionMemoryOperandValue(mem_operand_descr,
+                                              operand_values, length_values))
 
         for value in instrtype.instruction_checks.values():
             function, args = value
@@ -1709,11 +1700,9 @@ class Instruction(Pickable):
     @property
     def context_callbacks(self):
         """Returns the list of context callbacks registered."""
-        return [
-            (key, self._context_callback_check[key],
-             self._context_callback_fix[key])
-            for key in self._context_callback_check.keys()
-        ]
+        return [(key, self._context_callback_check[key],
+                 self._context_callback_fix[key])
+                for key in self._context_callback_check.keys()]
 
     def check_context(self, context):
         """
@@ -1765,9 +1754,8 @@ class Instruction(Pickable):
         for callback in self.context_callbacks:
             new_instruction.register_context_callback(*callback)
 
-        new_instruction.set_operands(
-            [op.value for op in self.operands()], check=False
-        )
+        new_instruction.set_operands([op.value for op in self.operands()],
+                                     check=False)
 
         for reg in self.allowed_regs:
             new_instruction.add_allow_register(reg)
@@ -1808,9 +1796,7 @@ class Instruction(Pickable):
             return self._operands[fieldname]
         except (KeyError, IndexError):
             raise MicroprobeLookupError(
-                "'%s' not in %s" %
-                (fieldname, list(
-                    self._operands.keys())))
+                "'%s' not in %s" % (fieldname, list(self._operands.keys())))
 
     def operand_fields(self):
         """Instruction field names of the operands.
@@ -2079,19 +2065,15 @@ def create_dependency_between_ins(output_ins, input_ins, context):
     reserved_registers = set(context.reserved_registers)
 
     output_operands = [
-        operand
-        for operand in output_ins.operands()
-        if operand.is_output and not operand.type.immediate and
-        not operand.type.address_relative and not operand.type.address_base and
-        not operand.type.address_index
+        operand for operand in output_ins.operands() if operand.is_output
+        and not operand.type.immediate and not operand.type.address_relative
+        and not operand.type.address_base and not operand.type.address_index
     ]
 
     input_operands = [
-        operand
-        for operand in input_ins.operands()
-        if operand.is_input and not operand.type.immediate and
-        not operand.type.address_relative and not operand.type.address_base and
-        not operand.type.address_index
+        operand for operand in input_ins.operands() if operand.is_input
+        and not operand.type.immediate and not operand.type.address_relative
+        and not operand.type.address_base and not operand.type.address_index
     ]
 
     # prioritize the operands that are only inputs or only outputs

--- a/src/microprobe/code/var.py
+++ b/src/microprobe/code/var.py
@@ -16,25 +16,27 @@
 """
 
 # Futures
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, annotations
 
 # Built-in modules
 import abc
 import hashlib
 import math
-
-# Third party modules
-import six
+from typing import TYPE_CHECKING, Dict, List
 
 # Own modules
 from microprobe.exceptions import MicroprobeCodeGenerationError
 from microprobe.utils.logger import get_logger
 
+# Type hinting
+if TYPE_CHECKING:
+    from microprobe.code.address import Address
+
 # Constants
 __all__ = ["Variable", "VariableSingle", "VariableArray"]
 LOG = get_logger(__name__)
 
-VAR_TYPE_LEN_DICT = {}
+VAR_TYPE_LEN_DICT: Dict[str, int] = {}
 VAR_TYPE_LEN_DICT["char"] = 1
 VAR_TYPE_LEN_DICT["signed char"] = 1
 VAR_TYPE_LEN_DICT["unsigned char"] = 1
@@ -91,50 +93,54 @@ VAR_TYPE_LEN_DICT["uint_fast64_t"] = 8
 
 
 # Classes
-class Variable(six.with_metaclass(abc.ABCMeta, object)):
+class Variable(abc.ABC):
     """ """
 
-    _cmp_attributes = []
+    _cmp_attributes: List[str] = []
 
     def __init__(self):
         """ """
         self._address = None
         self._hash = None
 
-    @abc.abstractproperty
-    def type(self):
+    @property
+    @abc.abstractmethod
+    def type(self) -> str:
         """Variable type (:class:`~.str`)."""
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def name(self):
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
         """Variable name (:class:`~.str`)."""
         raise NotImplementedError
 
-    @abc.abstractmethod
-    def array(self):
+    def array(self) -> bool:
         """Return if the variable is an array.
 
         :rtype: :class:`~.bool`
         """
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def size(self):
+    @property
+    @abc.abstractmethod
+    def size(self) -> int:
         """Variable size in bytes (::class:`~.int`)."""
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def value(self):
         """Variable value."""
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def align(self):
+    @property
+    @abc.abstractmethod
+    def align(self) -> int | None:
         """Variable alignment (:class:`~.int`)."""
         raise NotImplementedError
 
-    def set_address(self, address):
+    def set_address(self, address: Address):
         """Set variable address.
 
         :param address: Address of the variable.
@@ -146,12 +152,12 @@ class Variable(six.with_metaclass(abc.ABCMeta, object)):
         """Variable address (:class:`~.Address`)."""
         return self._address
 
-    @abc.abstractproperty
-    def __str__(self):
+    @abc.abstractmethod
+    def __str__(self) -> str:
         """ """
         raise NotImplementedError
 
-    def __eq__(self, other):
+    def __eq__(self, other: object):
         """x.__eq__(y) <==> x==y"""
 
         if not isinstance(other, self.__class__):
@@ -162,7 +168,7 @@ class Variable(six.with_metaclass(abc.ABCMeta, object)):
                 return False
         return True
 
-    def __ne__(self, other):
+    def __ne__(self, other: object):
         """x.__ne__(y) <==> x!=y"""
 
         if not isinstance(other, self.__class__):
@@ -173,7 +179,7 @@ class Variable(six.with_metaclass(abc.ABCMeta, object)):
                 return True
         return False
 
-    def __lt__(self, other):
+    def __lt__(self, other: object):
         """x.__lt__(y) <==> x<y"""
 
         if not isinstance(other, self.__class__):
@@ -186,7 +192,7 @@ class Variable(six.with_metaclass(abc.ABCMeta, object)):
                 return False
         return False
 
-    def __gt__(self, other):
+    def __gt__(self, other: object):
         """x.__gt__(y) <==> x>y"""
 
         if not isinstance(other, self.__class__):
@@ -199,7 +205,7 @@ class Variable(six.with_metaclass(abc.ABCMeta, object)):
                 return False
         return False
 
-    def __le__(self, other):
+    def __le__(self, other: object):
         """x.__le__(y) <==> x<=y"""
 
         if not isinstance(other, self.__class__):
@@ -212,7 +218,7 @@ class Variable(six.with_metaclass(abc.ABCMeta, object)):
                 return False
         return True
 
-    def __ge__(self, other):
+    def __ge__(self, other: object):
         """x.__ge__(y) <==> x>=y"""
 
         if not isinstance(other, self.__class__):
@@ -238,7 +244,12 @@ class VariableSingle(Variable):
 
     _cmp_attributes = ["name", "type", "size"]
 
-    def __init__(self, name, vartype, align=1, value=None, address=None):
+    def __init__(self,
+                 name: str,
+                 vartype: str,
+                 align: int = 1,
+                 value=None,
+                 address: Address | None = None):
         """
 
         :param name:
@@ -321,12 +332,12 @@ class VariableArray(Variable):
     _cmp_attributes = ["name", "type", "size"]
 
     def __init__(self,
-                 name,
-                 vartype,
-                 size,
-                 align=None,
+                 name: str,
+                 vartype: str,
+                 size: int,
+                 align: int | None = None,
                  value=None,
-                 address=None):
+                 address: Address | None = None):
         """
 
         :param name:

--- a/src/microprobe/code/var.py
+++ b/src/microprobe/code/var.py
@@ -30,7 +30,6 @@ import six
 from microprobe.exceptions import MicroprobeCodeGenerationError
 from microprobe.utils.logger import get_logger
 
-
 # Constants
 __all__ = ["Variable", "VariableSingle", "VariableArray"]
 LOG = get_logger(__name__)
@@ -230,8 +229,7 @@ class Variable(six.with_metaclass(abc.ABCMeta, object)):
         """ """
         if self._hash is None:
             self._hash = int(
-                hashlib.sha512(str(self).encode()).hexdigest(), 16
-            )
+                hashlib.sha512(str(self).encode()).hexdigest(), 16)
         return self._hash
 
 

--- a/src/microprobe/code/wrapper.py
+++ b/src/microprobe/code/wrapper.py
@@ -15,18 +15,24 @@
 This is the wrapper module documentation
 """
 # Futures
-from __future__ import absolute_import
+from __future__ import absolute_import, annotations
 
 # Built-in modules
 import abc
-
-# Third party modules
-import six
+from typing import TYPE_CHECKING, Callable, List
 
 # Own modules
 from microprobe.code.context import Context
 from microprobe.exceptions import MicroprobeCodeGenerationError
 from microprobe.utils.logger import get_logger
+
+# Type hinting
+if TYPE_CHECKING:
+    from microprobe.code.benchmark import Benchmark
+    from microprobe.code.ins import Instruction
+    from microprobe.code.var import Variable
+    from microprobe.target import Target
+    from microprobe.target.isa.register import Register
 
 # Constants
 LOG = get_logger(__name__)
@@ -36,7 +42,7 @@ __all__ = ["Wrapper"]
 
 
 # Classes
-class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
+class Wrapper(abc.ABC):
     """
     Abstract class to represent a language wrapper.
     """
@@ -51,7 +57,7 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
         self._direct_init_dict = None
 
     @abc.abstractmethod
-    def outputname(self, name):
+    def outputname(self, name: str) -> str:
         """
 
         :param name:
@@ -60,7 +66,7 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def headers(self):
+    def headers(self) -> str:
         """ """
         raise NotImplementedError
 
@@ -69,7 +75,7 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
     #    raise NotImplementedError
 
     @abc.abstractmethod
-    def declare_global_var(self, var):
+    def declare_global_var(self, var: Variable) -> str:
         """
 
         :param var:
@@ -78,7 +84,8 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def init_global_var(self, var, value):
+    def init_global_var(self, var: Variable,
+                        value: int | str | Callable[[], int | str]) -> str:
         """
 
         :param var:
@@ -88,22 +95,25 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def required_global_vars(self):
+    def required_global_vars(self) -> List[Variable]:
         """ """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def start_main(self):
+    def start_main(self) -> str:
         """ """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def post_var(self):
+    def post_var(self) -> str:
         """ """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def start_loop(self, instr, instr_reset, aligned=True):
+    def start_loop(self,
+                   instr: Instruction,
+                   instr_reset: Instruction,
+                   aligned: bool = True) -> str:
         """
 
         :param instr:
@@ -114,7 +124,7 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def wrap_ins(self, instr):
+    def wrap_ins(self, instr: Instruction) -> str:
         """
 
         :param instr:
@@ -123,7 +133,7 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def end_loop(self, instr):
+    def end_loop(self, instr: Instruction) -> str:
         """
 
         :param instr:
@@ -132,22 +142,23 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def end_main(self):
+    def end_main(self) -> str:
         """ """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def footer(self):
+    def footer(self) -> str:
         """ """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def infinite(self):
+    def infinite(self) -> bool:
         """Returns a :class:`~.bool` indicating if the loop is infinite. """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def reserved_registers(self, registers, target):
+    def reserved_registers(self, registers: List[Register],
+                           target: Target) -> List[Register]:
         """
 
         :param registers:
@@ -156,7 +167,7 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
         """
         raise NotImplementedError
 
-    def set_benchmark(self, bench):
+    def set_benchmark(self, bench: Benchmark):
         """
 
         :param bench:
@@ -174,7 +185,7 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
         """ """
         return self._reset_state
 
-    def set_target(self, target):
+    def set_target(self, target: Target):
         """
 
         :param target:

--- a/src/microprobe/code/wrapper.py
+++ b/src/microprobe/code/wrapper.py
@@ -28,7 +28,6 @@ from microprobe.code.context import Context
 from microprobe.exceptions import MicroprobeCodeGenerationError
 from microprobe.utils.logger import get_logger
 
-
 # Constants
 LOG = get_logger(__name__)
 __all__ = ["Wrapper"]
@@ -217,8 +216,7 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
             raise NotImplementedError
         else:
             raise MicroprobeCodeGenerationError(
-                "Direct intialization function called but not supported"
-            )
+                "Direct intialization function called but not supported")
 
     def get_direct_init(self, key, defaultvalue):
         """ Get the *value* for *key* """
@@ -230,8 +228,7 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
                 if len(keys) != 1:
                     raise MicroprobeCodeGenerationError(
                         "Unable to find the direct initialization value"
-                        " name: %s" % key
-                    )
+                        " name: %s" % key)
                 key = keys[0]
 
             if key in self._direct_init_dict:
@@ -241,10 +238,8 @@ class Wrapper(six.with_metaclass(abc.ABCMeta, object)):
                 return defaultvalue
 
             raise MicroprobeCodeGenerationError(
-                "Unable to find the direct initialization value"
-            )
+                "Unable to find the direct initialization value")
 
         else:
             raise MicroprobeCodeGenerationError(
-                "Direct intialization function called but not supported"
-            )
+                "Direct intialization function called but not supported")


### PR DESCRIPTION
This series has a few changes to start integrating type hints into the repo.

Commit 1: Run the [yapf command from utils/ensure_style.sh](https://github.com/IBM/microprobe/blob/master/dev_tools/utils/ensure_style.sh#L18) on the `/code` folder

Commit 2: Add basic type hints to files in the `/code` folder.
Notes:
- I added return types to the abstract classes. I typically like to avoid explicitly naming return types, as I think it encourages people to lie about the possibility of a `None` return type. These types may need to change as I understand/annotate more of the code base.
- I removed unused imports before adding types. This results in some interesting cases like [here](https://github.com/IBM/microprobe/commit/e71846462c902328fd6702e766b26f2a0b290b93#diff-97fbcb380bb363325cf3c5ef7fa4fa3776b15870aa0818f2daaebf0898592b55L61) where we remove Instruction and add it back as a type.
- I migrated some `**kwargs` patterns to regular `arg: type = default` patterns as `**kwarg`s are very challenging to type hint. [Example](https://github.com/IBM/microprobe/commit/e71846462c902328fd6702e766b26f2a0b290b93#diff-97fbcb380bb363325cf3c5ef7fa4fa3776b15870aa0818f2daaebf0898592b55L222)
  - This does cause some challenges [here](https://github.com/IBM/microprobe/commit/e71846462c902328fd6702e766b26f2a0b290b93#diff-97fbcb380bb363325cf3c5ef7fa4fa3776b15870aa0818f2daaebf0898592b55R601) where we need to propagate the types/defaults out to the sub-classes so the `init` method gets somewhat verbose.
- Migrated outdated `class ClassName(object):` and `ClassName(six.with_metaclass(abc.ABCMeta, object)):` to `class ClassName:` and `class ClassName(abc.ABC):`
    - **NOTE** I think this _might_ break compatibility with Python2, but I haven't checked. If that's important please let me know.
- Value/Variable annotations are extremely confusing to me at the moment, so I've left them un-annotated.
  - Examples: [1](https://github.com/IBM/microprobe/commit/e71846462c902328fd6702e766b26f2a0b290b93?diff=split#diff-c6cfbf1315085c5b90ca2c539aed628e99b0a8c5144ec186fea13794fe47b7ceR251), [2](https://github.com/IBM/microprobe/commit/e71846462c902328fd6702e766b26f2a0b290b93?diff=split#diff-c6cfbf1315085c5b90ca2c539aed628e99b0a8c5144ec186fea13794fe47b7ceR338), [3](https://github.com/IBM/microprobe/commit/e71846462c902328fd6702e766b26f2a0b290b93#diff-97fbcb380bb363325cf3c5ef7fa4fa3776b15870aa0818f2daaebf0898592b55R609)
- Replaced depricated `@abc.abstractproperty` with `@property  @abc.abstractmethod` [Example](https://github.com/IBM/microprobe/commit/e71846462c902328fd6702e766b26f2a0b290b93#diff-c6cfbf1315085c5b90ca2c539aed628e99b0a8c5144ec186fea13794fe47b7ceR106)

Commit 3: The facade pattern does not play nicely with python tooling :(
Thankfully an easy workaround is just defining the class methods as an alias on that class. 

Commit 4: `get_all_subclasses` does not (and AFAIK cannot) give useful type hints. Because we tightly control the call-site I feel comfortable wrapping the call in a function to provide type information.
