### PR TITLE
Seed randomness in `/passes` directory

### DIFF
--- a/src/microprobe/passes/ilp/__init__.py
+++ b/src/microprobe/passes/ilp/__init__.py
@@ -16,12 +16,10 @@
 """
 
 # Futures
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, annotations
 
 # Built-in modules
-import itertools
-import random
-import re
+from typing import TYPE_CHECKING
 
 # Third party modules
 
@@ -36,6 +34,9 @@ from microprobe.utils.misc import OrderedDict
 
 # Local modules
 
+# Type hinting
+if TYPE_CHECKING:
+    import random
 
 # Constants
 LOG = get_logger(__name__)
@@ -112,7 +113,7 @@ class RandomDependencyDistancePass(microprobe.passes.Pass):
 
     """
 
-    def __init__(self, maxdep):
+    def __init__(self, maxdep: int, rand: random.Random):
         """
 
         :param maxdep:
@@ -120,7 +121,7 @@ class RandomDependencyDistancePass(microprobe.passes.Pass):
         """
         super(RandomDependencyDistancePass, self).__init__()
         self._max = maxdep
-        self._func = random.randint
+        self._func = rand.randint
 
     def __call__(self, building_block, dummy_target):
         """

--- a/src/microprobe/passes/instruction/__init__.py
+++ b/src/microprobe/passes/instruction/__init__.py
@@ -16,14 +16,14 @@
 """
 
 # Futures
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, annotations
 
 # Built-in modules
 import copy
 import itertools
 import multiprocessing as mp
-import random
 import pickle
+from typing import TYPE_CHECKING, List
 
 # Third party modules
 from six.moves import range
@@ -49,8 +49,10 @@ from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import RejectingDict, closest_divisor, \
     Progress, iter_flatten, getnextf
 
-# Local modules
-
+# Type hinting
+if TYPE_CHECKING:
+    import random
+    from microprobe.code.ins import Instruction
 
 # Constants
 LOG = get_logger(__name__)
@@ -355,7 +357,7 @@ class SetRandomInstructionTypePass(microprobe.passes.Pass):
 
     """
 
-    def __init__(self, instructions):
+    def __init__(self, instructions: List[Instruction], rand: random.Random):
         """
 
         :param instructions:
@@ -363,9 +365,7 @@ class SetRandomInstructionTypePass(microprobe.passes.Pass):
         """
         super(SetRandomInstructionTypePass, self).__init__()
         self._instrs = instructions
-        myrandom = random.Random()
-        myrandom.seed(10)
-        self._func = myrandom.choice
+        self._func = rand.choice
 
     def __call__(self, building_block, target):
         """

--- a/targets/power/examples/power_v206_power7_ppc64_linux_gcc_random.py
+++ b/targets/power/examples/power_v206_power7_ppc64_linux_gcc_random.py
@@ -93,17 +93,21 @@ def generate(name):
 
     print_info("Generating %d..." % name)
 
+    # Seed the randomness
+    rand = random.Random()
+    rand.seed(64)  # My favorite number ;)
+
     # Generate a random memory model (used afterwards)
     model = []
     total = 100
     for mcomp in CACHE_HIERARCHY[0:-1]:
-        weight = random.randint(0, total)
+        weight = rand.randint(0, total)
         model.append(weight)
         print_info("%s: %d%%" % (mcomp, weight))
         total = total - weight
 
     # Fix remaining
-    level = random.randint(0, len(CACHE_HIERARCHY[0:-1]) - 1)
+    level = rand.randint(0, len(CACHE_HIERARCHY[0:-1]) - 1)
     model[level] += total
 
     # Last level always zero
@@ -124,7 +128,7 @@ def generate(name):
     # Define function to return random numbers (used afterwards)
     def rnd():
         """Return a random value. """
-        return random.randrange(0, (1 << 64) - 1)
+        return rand.randrange(0, (1 << 64) - 1)
 
     # Create the benchmark synthesizer
     synth = microprobe.code.Synthesizer(TARGET, cwrapper())
@@ -182,7 +186,7 @@ def generate(name):
 
     synth.add_pass(
         microprobe.passes.instruction.SetRandomInstructionTypePass(
-            instructions
+            instructions, rand
         )
     )
 
@@ -197,7 +201,7 @@ def generate(name):
     #     distance is randomly picked
     synth.add_pass(
         microprobe.passes.register.DefaultRegisterAllocationPass(
-            dd=random.randint(1, 20)
+            dd=rand.randint(1, 20)
         )
     )
 

--- a/targets/riscv/examples/riscv_branch.py
+++ b/targets/riscv/examples/riscv_branch.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import
 
 # Built-in modules
 import os
+from random import Random
 import sys
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 
@@ -131,6 +132,8 @@ class RiscvIpcTest(object):
             str.format("{}-{}-{}",
                        self.args.isa, self.args.uarch, self.args.env)
         )
+        self._rand = Random()
+        self._rand.seed(64)  # My favorite number ;)
 
     def emit(self):
 
@@ -194,8 +197,9 @@ class RiscvIpcTest(object):
             )
         else:
             p = instruction.SetRandomInstructionTypePass(
-                   [self.target.isa.instructions[elem]
-                    for elem in valid_instrs_names + branch_instrs_names]
+                [self.target.isa.instructions[elem]
+                    for elem in valid_instrs_names + branch_instrs_names],
+                self._rand
             )
 
         synth.add_pass(p)

--- a/targets/riscv/examples/riscv_ipc.py
+++ b/targets/riscv/examples/riscv_ipc.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import
 
 # Built-in modules
 import os
+from random import Random
 import sys
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 
@@ -100,6 +101,8 @@ class RiscvIpcTest(object):
             str.format("{}-{}-{}",
                        self.args.isa, self.args.uarch, self.args.env)
         )
+        self._rand = Random()
+        self._rand.seed(64)  # My favorite number ;)
 
     def emit(self):
         # Do not touch pointer registers
@@ -134,7 +137,9 @@ class RiscvIpcTest(object):
                 )
                 passes = [
                     structure.SimpleBuildingBlockPass(self.args.loop_size),
-                    instruction.SetRandomInstructionTypePass([instr]),
+                    instruction.SetRandomInstructionTypePass(
+                        [instr], self._rand
+                    ),
                     initialization.ReserveRegistersPass(reserved_registers),
                     branch.BranchNextPass(),
                     memory.GenericMemoryStreamsPass(

--- a/targets/riscv/examples/riscv_ipc_c.py
+++ b/targets/riscv/examples/riscv_ipc_c.py
@@ -25,6 +25,7 @@ from __future__ import absolute_import
 
 # Built-in modules
 import os
+from random import Random
 import sys
 from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 
@@ -100,6 +101,8 @@ class RiscvIpcTest(object):
             str.format("{}-{}-{}",
                        self.args.isa, self.args.uarch, self.args.env)
         )
+        self._rand = Random()
+        self._rand.seed(64)  # My favorite number ;)
 
     def emit(self):
         # Do not touch pointer registers
@@ -132,7 +135,9 @@ class RiscvIpcTest(object):
                 )
                 passes = [
                     structure.SimpleBuildingBlockPass(self.args.loop_size),
-                    instruction.SetRandomInstructionTypePass([instr]),
+                    instruction.SetRandomInstructionTypePass(
+                        [instr], self._rand
+                    ),
                     initialization.ReserveRegistersPass(reserved_registers),
                     branch.BranchNextPass(),
                     memory.GenericMemoryStreamsPass(


### PR DESCRIPTION
This PR eliminates unseeded `random.Random()` calls from `/passes`.
It now accepts the seeded generator as an argument when the pass is constructed so the user can easily set the seed.