### PR TITLE
Add some type hints to `src/microprobe/target` folder

### DIFF
--- a/src/microprobe/target/__init__.py
+++ b/src/microprobe/target/__init__.py
@@ -59,7 +59,6 @@ from microprobe.utils.misc import Pickable, RejectingDict, findfiles
 
 # Local modules
 
-
 # Constants
 LOG = get_logger(__name__)
 __all__ = [
@@ -94,19 +93,15 @@ def import_definition(definition_tuple):
 
     isa_def, uarch_def, env_def = definition_tuple
     isa = import_isa_definition(os.path.dirname(isa_def.filename))
-    env = import_env_definition(
-        env_def.filename, isa,
-        definition_name=env_def.name
-    )
+    env = import_env_definition(env_def.filename,
+                                isa,
+                                definition_name=env_def.name)
     uarch = import_microarchitecture_definition(
-        os.path.dirname(uarch_def.filename)
-    )
+        os.path.dirname(uarch_def.filename))
 
     target = Target(isa, uarch=uarch, env=env)
-    LOG.info(
-        "Target '%s-%s-%s' imported", isa_def.name, uarch_def.name,
-        env_def.name
-    )
+    LOG.info("Target '%s-%s-%s' imported", isa_def.name, uarch_def.name,
+             env_def.name)
     LOG.debug("End importing definition tuple")
     return target
 
@@ -133,44 +128,40 @@ def _parse_definition_tuple(definition_tuple):
         isa_def, architecture_def, env_def = definition_tuple.split("-")
     except ValueError:
         raise MicroprobeTargetDefinitionError(
-            "Invalid format of '%s' target tuple" % definition_tuple
-        )
+            "Invalid format of '%s' target tuple" % definition_tuple)
 
     definitions = find_isa_definitions()
     if isa_def not in [definition.name for definition in definitions]:
-        raise MicroprobeTargetDefinitionError(
-            "ISA '%s' not available" % isa_def
-        )
+        raise MicroprobeTargetDefinitionError("ISA '%s' not available" %
+                                              isa_def)
     else:
         isa_def = [
-            definition
-            for definition in definitions if definition.name == isa_def
+            definition for definition in definitions
+            if definition.name == isa_def
         ][-1]
 
     definitions = find_microarchitecture_definitions()
     if architecture_def not in [definition.name for definition in definitions]:
         raise MicroprobeTargetDefinitionError(
-            "Microarchitecture '%s' not available" % architecture_def
-        )
+            "Microarchitecture '%s' not available" % architecture_def)
     else:
         architecture_def = [
-            definition
-            for definition in definitions
+            definition for definition in definitions
             if definition.name == architecture_def
         ][-1]
 
     definitions = find_env_definitions()
     if env_def not in [definition.name for definition in definitions]:
         raise MicroprobeTargetDefinitionError(
-            "Environment '%s' not available. " % env_def
-        )
+            "Environment '%s' not available. " % env_def)
     else:
         env_def = [
-            definition
-            for definition in definitions if definition.name == env_def
+            definition for definition in definitions
+            if definition.name == env_def
         ][-1]
 
     return (isa_def, architecture_def, env_def)
+
 
 # def import_policies(target_name):
 #    """Return the dictionary of policies for the *target_name*."""
@@ -225,8 +216,7 @@ class Definition(object):
     _field2 = 25
     _field3 = 78 - _field1 - _field2
     _fmt_str_ = "Name:'%%%ds', Description:'%%%ds', File:'%%%ds'" % (
-        _field1, _field2, _field3
-    )
+        _field1, _field2, _field3)
     _cmp_attributes = ["name", "description", "filename"]
 
     def __init__(self, filename, name, description):
@@ -266,11 +256,8 @@ class Definition(object):
 
     def _check_cmp(self, other):
         if not isinstance(other, self.__class__):
-            raise NotImplementedError(
-                "%s != %s" % (
-                    other.__class__, self.__class__
-                )
-            )
+            raise NotImplementedError("%s != %s" %
+                                      (other.__class__, self.__class__))
 
     def __eq__(self, other):
         """x.__eq__(y) <==> x==y"""
@@ -364,18 +351,13 @@ class Target(Pickable):
 
         if uarch is not None:
             self.set_uarch(uarch)
-            self.microarchitecture.add_properties_to_isa(
-                self.isa.instructions
-            )
+            self.microarchitecture.add_properties_to_isa(self.isa.instructions)
 
         if env is not None:
             self.set_env(env)
         else:
             self.set_env(
-                GenericEnvironment(
-                    "Default", "Empty environment", self.isa
-                )
-            )
+                GenericEnvironment("Default", "Empty environment", self.isa))
 
     @property
     def name(self):
@@ -394,20 +376,16 @@ class Target(Pickable):
         description.append("Target ISA: %s" % self.isa.name)
         description.append("ISA Description: %s" % self.isa.description)
         if self.microarchitecture is not None:
-            description.append(
-                "Target Micro-architecture: %s" % self.microarchitecture.name
-            )
-            description.append(
-                "Micro-architecture Description: %s" %
-                self.microarchitecture.description
-            )
+            description.append("Target Micro-architecture: %s" %
+                               self.microarchitecture.name)
+            description.append("Micro-architecture Description: %s" %
+                               self.microarchitecture.description)
         else:
             description.append("Target Micro-architecture: Not defined")
             description.append("Micro-architecture Description: Not defined")
         description.append("Target Environment: %s" % self.environment.name)
-        description.append(
-            "Environment description: %s" % self.environment.description
-        )
+        description.append("Environment description: %s" %
+                           self.environment.description)
         return "\n".join(description)
 
     @property
@@ -470,8 +448,7 @@ class Target(Pickable):
                 value = getattr(instr, prop_name)
             except AttributeError:
                 raise MicroprobeTargetDefinitionError(
-                    "Property '%s' for instruction not found" % prop_name
-                )
+                    "Property '%s' for instruction not found" % prop_name)
 
             if not isinstance(value, list):
                 values = [value]
@@ -572,7 +549,5 @@ class Target(Pickable):
             else:
                 raise MicroprobeError("Attribute defined in multiple objects")
         else:
-            raise AttributeError(
-                "'%s' object has no attribute '%s'" %
-                (self.__class__.__name__, name)
-            )
+            raise AttributeError("'%s' object has no attribute '%s'" %
+                                 (self.__class__.__name__, name))

--- a/src/microprobe/target/env/__init__.py
+++ b/src/microprobe/target/env/__init__.py
@@ -16,12 +16,14 @@
 """
 
 # Futures
-from __future__ import absolute_import
+from __future__ import absolute_import, annotations
 
 # Built-in modules
 import abc
+from typing import TYPE_CHECKING, List
 
 # Third party modules
+import six
 
 # Own modules
 from microprobe import MICROPROBE_RC
@@ -33,10 +35,16 @@ from microprobe.exceptions import MicroprobeImportDefinitionError, \
 from microprobe.property import Property, PropertyHolder
 from microprobe.utils.imp import find_subclasses
 from microprobe.utils.logger import get_logger
-from microprobe.utils.misc import RejectingOrderedDict, findfiles
-import six
+from microprobe.utils.misc import findfiles
 
 # Local modules
+
+# Type hinting
+if TYPE_CHECKING:
+    from microprobe.target.isa import ISA
+    from microprobe.code.ins import Instruction
+    from microprobe.target import Target
+    from microprobe.target.isa.register import Register
 
 # Constants
 LOG = get_logger(__name__)
@@ -50,7 +58,9 @@ __all__ = [
 
 
 # Functions
-def import_env_definition(module, isa, definition_name=None):
+def import_env_definition(module,
+                          isa: ISA,
+                          definition_name: str | None = None):
     """
 
     :param module:
@@ -89,7 +99,7 @@ def import_env_definition(module, isa, definition_name=None):
     return environment
 
 
-def find_env_definitions(paths=None):
+def find_env_definitions(paths: List[str] | None = None):
 
     LOG.debug("Start find environment definitions")
 
@@ -107,7 +117,7 @@ def find_env_definitions(paths=None):
     paths = paths + MICROPROBE_RC["environment_paths"] \
         + MICROPROBE_RC["default_paths"]
 
-    results = []
+    results: List[Definition] = []
     files = findfiles(paths, "env/.*.py$", full=True)
 
     if len(files) > 0:
@@ -146,32 +156,31 @@ class Environment(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
 
     @abc.abstractmethod
     def __init__(self):
-        """ """
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def name(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def description(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def isa(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def environment_reserved_registers(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def threads(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -185,7 +194,6 @@ class Environment(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
 
     @abc.abstractmethod
     def __str__(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -199,47 +207,43 @@ class Environment(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
 
     @abc.abstractmethod
     def full_report(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def default_wrapper(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def stack_pointer(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def stack_direction(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def elf_abi(self, stack_size, start_symbol):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def function_call(self, target, return_address_reg=None, long_jump=False):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def function_return(self, return_address_reg=None):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def volatile_registers(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def little_endian(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -251,34 +255,29 @@ class Environment(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
         """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def target(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def hook_before_test_instructions(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def hook_after_test_instructions(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def hook_test_init_instructions(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def hook_after_reset_instructions(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def hook_test_end_instructions(self):
-        """ """
         raise NotImplementedError
 
 
@@ -287,7 +286,11 @@ class GenericEnvironment(Environment):
 
     _cmp_attributes = ["name", "descr"]
 
-    def __init__(self, name, descr, isa, little_endian=False):
+    def __init__(self,
+                 name: str,
+                 descr: str,
+                 isa: ISA,
+                 little_endian: bool = False):
         """
 
         :param name:
@@ -299,7 +302,7 @@ class GenericEnvironment(Environment):
         self._name = name
         self._description = descr
         self._isa = isa
-        self._reserved_registers = []
+        self._reserved_registers: List[Register] = []
         self._threads = 1
         self._target = None
         self._default_wrapper = None
@@ -312,35 +315,29 @@ class GenericEnvironment(Environment):
 
     @property
     def name(self):
-        """ """
         return self._name
 
     @property
     def description(self):
-        """ """
         return self._description
 
     @property
     def isa(self):
-        """ """
         return self._isa
 
     @property
     def environment_reserved_registers(self):
-        """ """
         return self._reserved_registers
 
     @property
     def threads(self):
-        """ """
         return self._threads
 
     @property
     def target(self):
-        """ """
         return self._target
 
-    def set_target(self, target):
+    def set_target(self, target: Target):
         """
 
         :param target:
@@ -348,7 +345,7 @@ class GenericEnvironment(Environment):
         """
         self._target = target
 
-    def set_threads(self, num_threads):
+    def set_threads(self, num_threads: int):
         """
 
         :param num_threads:
@@ -357,10 +354,9 @@ class GenericEnvironment(Environment):
         self._threads = num_threads
 
     def __str__(self):
-        """ """
         return "Environment '%s': %s" % (self.name, self.description)
 
-    def register_name(self, register):
+    def register_name(self, register: str):
         """
 
         :param register:
@@ -372,28 +368,29 @@ class GenericEnvironment(Environment):
             register)
 
     def full_report(self):
-        """ """
         return str(self)
 
     @property
     def default_wrapper(self):
-        """ """
         return self._default_wrapper
 
-    def elf_abi(self, stack_size, start_symbol, **kwargs):
-        """ """
+    def elf_abi(self,
+                stack_size: int,
+                start_symbol,
+                stack_name: str = "microprobe stack",
+                stack_alignment: int = 16,
+                stack_address: Address | None = None,
+                **kwargs):
 
-        stack = VariableArray(kwargs.get("stack_name", "microprobe_stack"),
+        stack = VariableArray(stack_name,
                               "uint8_t",
                               stack_size,
-                              align=kwargs.get("stack_alignment", 16),
-                              address=kwargs.get("stack_address", None))
+                              align=stack_alignment,
+                              address=stack_address)
 
-        instructions = []
+        instructions: List[Instruction] = []
         instructions += self.target.set_register_to_address(
-            self.stack_pointer,
-            Address(base_address=kwargs.get("stack_name", "microprobe_stack")),
-            Context())
+            self.stack_pointer, Address(base_address=stack_name), Context())
 
         if self.stack_direction == "decrease":
             instructions += self.target.add_to_register(
@@ -407,30 +404,29 @@ class GenericEnvironment(Environment):
 
         return [stack], instructions
 
-    def function_call(self, target, return_address_reg=None, long_jump=False):
-        """ """
+    def function_call(self,
+                      target: Target,
+                      return_address_reg: Register | None = None,
+                      long_jump: bool = False):
         raise NotImplementedError
 
-    def function_return(self, return_address_reg=None):
-        """ """
+    def function_return(self, return_address_reg: Register | None = None):
         raise NotImplementedError
 
     @property
     def volatile_registers(self):
-        """ """
         raise NotImplementedError
 
+    @property
     def stack_pointer(self):
-        """ """
         raise NotImplementedError
 
+    @property
     def stack_direction(self):
-        """ """
         raise NotImplementedError
 
     @property
     def little_endian(self):
-        """ """
         return self._little_endian
 
     def _check_cmp(self, other):
@@ -496,21 +492,16 @@ class GenericEnvironment(Environment):
         return True
 
     def hook_before_test_instructions(self):
-        """ """
         return []
 
     def hook_after_test_instructions(self):
-        """ """
         return [self._target.nop()]
 
     def hook_test_init_instructions(self):
-        """ """
         return []
 
     def hook_after_reset_instructions(self):
-        """ """
         return []
 
     def hook_test_end_instructions(self):
-        """ """
         return []

--- a/src/microprobe/target/env/__init__.py
+++ b/src/microprobe/target/env/__init__.py
@@ -38,7 +38,6 @@ import six
 
 # Local modules
 
-
 # Constants
 LOG = get_logger(__name__)
 
@@ -62,12 +61,9 @@ def import_env_definition(module, isa, definition_name=None):
 
     LOG.info("Start Environment import")
     envcls = list(
-        find_subclasses(
-            module,
-            GenericEnvironment,
-            extra_import_name=definition_name
-        )
-    )
+        find_subclasses(module,
+                        GenericEnvironment,
+                        extra_import_name=definition_name))
 
     LOG.debug("Definition name: %s", definition_name)
     LOG.debug("Classes: %s", envcls)
@@ -76,20 +72,16 @@ def import_env_definition(module, isa, definition_name=None):
         envcls = [cls for cls in envcls if cls.__name__ == definition_name]
 
     if len(envcls) > 1 and definition_name is None:
-        LOG.warning(
-            "Multiple environment definitions found and a specific"
-            " name not provided. Taking the first one."
-        )
+        LOG.warning("Multiple environment definitions found and a specific"
+                    " name not provided. Taking the first one.")
     elif len(envcls) < 1 and definition_name is None:
         raise MicroprobeImportDefinitionError(
-            "No environment definitions found in '%s'" % module
-        )
+            "No environment definitions found in '%s'" % module)
 
     elif len(envcls) < 1:
         raise MicroprobeImportDefinitionError(
             "No environment definitions found in '%s' with name"
-            " '%s'" % (module, definition_name)
-        )
+            " '%s'" % (module, definition_name))
 
     environment = envcls[0](isa)
 
@@ -316,9 +308,7 @@ class GenericEnvironment(Environment):
             Property(
                 "problem_state", "Boolean indicating if the program"
                 " is executed in the problem state"
-                " (not privilege level)", True
-            )
-        )
+                " (not privilege level)", True))
 
     @property
     def name(self):
@@ -378,8 +368,8 @@ class GenericEnvironment(Environment):
         """
         raise NotImplementedError(
             "Register name translation requested but not implemented. Check"
-            " if you are targeting the appropriate environment (%s)" % register
-        )
+            " if you are targeting the appropriate environment (%s)" %
+            register)
 
     def full_report(self):
         """ """
@@ -393,29 +383,21 @@ class GenericEnvironment(Environment):
     def elf_abi(self, stack_size, start_symbol, **kwargs):
         """ """
 
-        stack = VariableArray(
-            kwargs.get("stack_name", "microprobe_stack"),
-            "uint8_t",
-            stack_size,
-            align=kwargs.get("stack_alignment", 16),
-            address=kwargs.get("stack_address", None)
-        )
+        stack = VariableArray(kwargs.get("stack_name", "microprobe_stack"),
+                              "uint8_t",
+                              stack_size,
+                              align=kwargs.get("stack_alignment", 16),
+                              address=kwargs.get("stack_address", None))
 
         instructions = []
         instructions += self.target.set_register_to_address(
             self.stack_pointer,
-            Address(
-                base_address=kwargs.get(
-                    "stack_name", "microprobe_stack"
-                )
-            ),
-            Context()
-        )
+            Address(base_address=kwargs.get("stack_name", "microprobe_stack")),
+            Context())
 
         if self.stack_direction == "decrease":
             instructions += self.target.add_to_register(
-                self.stack_pointer, stack_size
-            )
+                self.stack_pointer, stack_size)
 
         if start_symbol is not None:
             instructions += self.target.function_call(start_symbol)
@@ -454,11 +436,8 @@ class GenericEnvironment(Environment):
     def _check_cmp(self, other):
 
         if not isinstance(other, self.__class__):
-            raise NotImplementedError(
-                "%s != %s" % (
-                    other.__class__, self.__class__
-                )
-            )
+            raise NotImplementedError("%s != %s" %
+                                      (other.__class__, self.__class__))
 
     def __eq__(self, other):
         """x.__eq__(y) <==> x==y"""

--- a/src/microprobe/target/isa/__init__.py
+++ b/src/microprobe/target/isa/__init__.py
@@ -16,23 +16,23 @@
 """
 
 # Futures
-from __future__ import absolute_import
+from __future__ import absolute_import, annotations
 
 # Built-in modules
 import abc
 import os
+from typing import TYPE_CHECKING, List, Dict
 
 # Third party modules
 
 # Own modules
 import microprobe.code.ins
 from microprobe import MICROPROBE_RC
-from microprobe.code.address import Address, InstructionAddress
+from microprobe.code.address import InstructionAddress
 from microprobe.code.context import Context
 from microprobe.code.var import VariableArray
-from microprobe.exceptions import MicroprobeArchitectureDefinitionError, \
-    MicroprobeCodeGenerationError, MicroprobeTargetDefinitionError, \
-    MicroprobeYamlFormatError
+from microprobe.exceptions import MicroprobeCodeGenerationError, \
+    MicroprobeTargetDefinitionError, MicroprobeYamlFormatError
 from microprobe.target.isa import comparator as comparator_mod
 from microprobe.target.isa import generator as generator_mod
 from microprobe.target.isa import instruction as instruction_mod
@@ -45,11 +45,17 @@ from microprobe.target.isa.dat import GenericDynamicAddressTranslation
 from microprobe.utils.imp import get_object_from_module, \
     import_cls_definition, import_definition, import_operand_definition
 from microprobe.utils.logger import DEBUG, get_logger
-from microprobe.utils.misc import dict2OrderedDict, findfiles, natural_sort
+from microprobe.utils.misc import dict2OrderedDict, findfiles
 from microprobe.utils.yaml import read_yaml
-import six
 
 # Local modules
+
+# Type hinting
+if TYPE_CHECKING:
+    from microprobe.target import Definition, Target
+    from microprobe.target.isa.register import Register
+    from microprobe.code.var import Variable
+    from microprobe.code.ins import Instruction, InstructionType
 
 # Constants
 SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
@@ -63,7 +69,7 @@ __all__ = [
 
 
 # Functions
-def _read_isa_extensions(isadefs, path):
+def _read_isa_extensions(isadefs: List[Dict[str, str]], path: str):
     """
 
     :param isadefs:
@@ -85,7 +91,7 @@ def _read_isa_extensions(isadefs, path):
         _read_isa_extensions(isadefs, isadefval)
 
 
-def _read_yaml_definition(isadefs, path):
+def _read_yaml_definition(isadefs: List[Dict[str, str]], path: str):
     """
 
     :param isadefs:
@@ -163,7 +169,7 @@ def _read_yaml_definition(isadefs, path):
     return complete_isadef
 
 
-def import_isa_definition(path):
+def import_isa_definition(path: str):
     """Imports a ISA definition given a path
 
     :param path:
@@ -296,7 +302,7 @@ def import_isa_definition(path):
     return isa
 
 
-def find_isa_definitions(paths=None):
+def find_isa_definitions(paths: List[str] | None = None):
 
     if paths is None:
         paths = []
@@ -304,7 +310,7 @@ def find_isa_definitions(paths=None):
     paths = paths + MICROPROBE_RC["architecture_paths"] \
         + MICROPROBE_RC["default_paths"]
 
-    results = []
+    results: List[Definition] = []
     isafiles = findfiles(paths, "^isa.yaml$")
 
     if len(isafiles) > 0:
@@ -334,7 +340,7 @@ def find_isa_definitions(paths=None):
 
 
 # Classes
-class ISA(six.with_metaclass(abc.ABCMeta, object)):
+class ISA(abc.ABC):
     """Abstract class to represent an Instruction Set Architecture (ISA).
 
     An instruction set architecture (ISA) object defines the part of the
@@ -344,82 +350,84 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
 
     @abc.abstractmethod
     def __init__(self):
-        """ """
         pass
 
-    @abc.abstractproperty
-    def name(self):
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
         """ISA name (:class:`~.str`)."""
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def description(self):
+    @property
+    @abc.abstractmethod
+    def description(self) -> str:
         """ISA description (:class:`~.str`)."""
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def path(self):
+    @property
+    @abc.abstractmethod
+    def path(self) -> str:
         """Path to definition (:class:`~.str`)."""
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def instructions(self):
+    @property
+    @abc.abstractmethod
+    def instructions(self) -> Dict[str, InstructionType]:
         """ISA instructions (:class:`~.dict` mapping strings to
-           :class:`~.InstructionType`). """
+        :class:`~.InstructionType`)."""
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def target(self):
+    @property
+    @abc.abstractmethod
+    def target(self) -> Target:
         """Associated target object (:class:`~.Target`)."""
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def registers(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def registers(self) -> Dict[str, Register]:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def scratch_registers(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def scratch_registers(self) -> List[Register]:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def address_registers(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def address_registers(self) -> List[Register]:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def float_registers(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def float_registers(self) -> List[Register]:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def control_registers(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def control_registers(self) -> List[Register]:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def scratch_var(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def scratch_var(self) -> Variable:
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def context_var(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def __str__(self):
-        """ """
+    def __str__(self) -> str:
         raise NotImplementedError
 
     @abc.abstractmethod
     def full_report(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_register(self, reg, value, context):
+    def set_register(self, reg: Register, value, context: Context):
         """
 
         :param reg:
@@ -430,7 +438,7 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def negate_register(self, reg, context):
+    def negate_register(self, reg: Register, context: Context):
         """
 
         :param reg:
@@ -440,18 +448,7 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def load(self, reg, address, context):
-        """
-
-        :param reg:
-        :param address:
-        :param context:
-
-        """
-        raise NotImplementedError
-
-    @abc.abstractmethod
-    def load_float(self, reg, address, context):
+    def load(self, reg: Register, address, context: Context):
         """
 
         :param reg:
@@ -462,7 +459,7 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def store_float(self, reg, address, context):
+    def load_float(self, reg: Register, address, context: Context):
         """
 
         :param reg:
@@ -473,7 +470,18 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def store_integer(self, reg, address, length, context):
+    def store_float(self, reg: Register, address, context: Context):
+        """
+
+        :param reg:
+        :param address:
+        :param context:
+
+        """
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def store_integer(self, reg: Register, address, length, context: Context):
         """
 
         :param reg:
@@ -485,7 +493,7 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def store_decimal(self, address, length, value, context):
+    def store_decimal(self, address, length, value, context: Context):
         """
 
         :param address:
@@ -498,11 +506,11 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
 
     @abc.abstractmethod
     def set_register_to_address(self,
-                                reg,
+                                reg: Register,
                                 address,
-                                context,
-                                force_absolute=False,
-                                force_relative=False):
+                                context: Context,
+                                force_absolute: bool = False,
+                                force_relative: bool = False):
         """
 
         :param reg:
@@ -514,7 +522,7 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_register_for_address_arithmetic(self, context):
+    def get_register_for_address_arithmetic(self, context: Context):
         """
 
         :param context:
@@ -523,7 +531,7 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_register_for_float_arithmetic(self, context):
+    def get_register_for_float_arithmetic(self, context: Context):
         """
 
         :param context:
@@ -532,7 +540,8 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_register_bits(self, register, value, mask, shift, context):
+    def set_register_bits(self, register, value, mask, shift,
+                          context: Context):
         """
 
         :param register:
@@ -545,7 +554,7 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def new_instruction(self, name):
+    def new_instruction(self, name: str):
         """
 
         :param name:
@@ -554,7 +563,7 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_target(self, target):
+    def set_target(self, target: Target):
         """
 
         :param target:
@@ -563,7 +572,7 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def add_to_register(self, register, value):
+    def add_to_register(self, register: Register, value):
         """
 
         :param register:
@@ -573,7 +582,7 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def branch_unconditional_relative(self, source, target):
+    def branch_unconditional_relative(self, source, target: Target):
         """
 
         :param source:
@@ -587,7 +596,7 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def compare_and_branch(self, val1, val2, cond, target, context):
+    def compare_and_branch(self, val1, val2, cond, target, context: Context):
         """
 
         :param val1:
@@ -601,37 +610,31 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
 
     @abc.abstractmethod
     def nop(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def flag_registers(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def get_dat(self, **kwargs):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def set_context(self, variable=None, tmpl_path=None):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def get_context(self, variable=None, tmpl_path=None):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def register_value_comparator(self, comp):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def normalize_asm(self, mnemonic, operands):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -642,7 +645,9 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
 class GenericISA(ISA):
     """Class to represent a generic Instruction Set Architecture (ISA)."""
 
-    def __init__(self, name, descr, path, ins, regs, comparators, generators):
+    def __init__(self, name: str, descr: str, path: str,
+                 ins: Dict[str, InstructionType], regs: Dict[str, Register],
+                 comparators, generators):
         """
 
         :param name:
@@ -676,9 +681,9 @@ class GenericISA(ISA):
         for generator in generators:
             self._generators.append(generator(self))
 
-        self._scratch_registers = []
-        self._control_registers = []
-        self._flag_registers = []
+        self._scratch_registers: List[Register] = []
+        self._control_registers: List[Register] = []
+        self._flag_registers: List[Register] = []
 
         self._scratch_var = VariableArray(
             ("%s_scratch_var" % self._name).upper(), "char", 256, align=8)
@@ -686,12 +691,10 @@ class GenericISA(ISA):
 
     @property
     def name(self):
-        """ """
         return self._name
 
     @property
     def description(self):
-        """ """
         return self._descr
 
     @property
@@ -701,44 +704,36 @@ class GenericISA(ISA):
 
     @property
     def address_registers(self):
-        """ """
         return self._address_registers
 
     @property
     def float_registers(self):
-        """ """
         return self._float_registers
 
     @property
     def flag_registers(self):
-        """ """
         return self._flag_registers
 
     @property
     def instructions(self):
-        """ """
         return self._instructions
 
     @property
     def scratch_var(self):
-        """ """
         return self._scratch_var
 
     @property
     def registers(self):
-        """ """
         return self._registers
 
     @property
     def target(self):
-        """ """
         return self._target
 
     def normalize_asm(self, mnemonic, operands):
-        """ """
         return mnemonic, operands
 
-    def set_target(self, target):
+    def set_target(self, target: Target):
         """
 
         :param target:
@@ -747,10 +742,9 @@ class GenericISA(ISA):
         self._target = target
 
     def __str__(self):
-        """ """
         return "ISA Name: %s - %s" % (self.name, self.description)
 
-    def new_instruction(self, name):
+    def new_instruction(self, name: str):
         """
 
         :param name:
@@ -760,7 +754,6 @@ class GenericISA(ISA):
         return microprobe.code.ins.instruction_factory(ins_type)
 
     def full_report(self):
-        """ """
         rstr = "-" * 80 + "\n"
         rstr += "ISA Name: %s\n" % self.name
         rstr += "ISA Description: %s\n" % self.name
@@ -784,7 +777,7 @@ class GenericISA(ISA):
         rstr += "-" * 80 + "\n"
         return rstr
 
-    def set_register(self, reg, value, context):
+    def set_register(self, reg: Register, value, context: Context):
         """
 
         :param reg:
@@ -797,15 +790,13 @@ class GenericISA(ISA):
 
     @property
     def scratch_registers(self):
-        """ """
         return self._scratch_registers
 
     @property
     def control_registers(self):
-        """ """
         return self._control_registers
 
-    def get_register_for_address_arithmetic(self, context):
+    def get_register_for_address_arithmetic(self, context: Context):
         """
 
         :param context:
@@ -825,7 +816,7 @@ class GenericISA(ISA):
         reg = reg[1:] + [reg[0]]
         return reg[0]
 
-    def get_register_for_float_arithmetic(self, context):
+    def get_register_for_float_arithmetic(self, context: Context):
         """
 
         :param context:
@@ -843,7 +834,7 @@ class GenericISA(ISA):
         reg = reg[1:] + [reg[0]]
         return reg[0]
 
-    def add_to_register(self, register, value):
+    def add_to_register(self, register: Register, value):
         """
 
         :param register:
@@ -852,7 +843,7 @@ class GenericISA(ISA):
         """
         super(GenericISA, self).add_to_register(register, value)
 
-    def branch_unconditional_relative(self, source, target):
+    def branch_unconditional_relative(self, source, target: Target):
         """
 
         :param source:
@@ -870,11 +861,9 @@ class GenericISA(ISA):
         return instr
 
     def get_dat(self, **kwargs):
-        """ """
         return GenericDynamicAddressTranslation(self, **kwargs)
 
     def set_context(self, variable=None, tmpl_path=None, complete=False):
-        """ """
 
         if variable is None:
             variable = self.context_var
@@ -900,8 +889,10 @@ class GenericISA(ISA):
             return instrs + microprobe.code.ins.instructions_from_asm(
                 asm, self.target, labels=[variable.name])
 
-    def get_context(self, variable=None, tmpl_path=None, complete=False):
-        """ """
+    def get_context(self,
+                    variable=None,
+                    tmpl_path=None,
+                    complete: bool = False):
 
         if variable is None:
             variable = self.context_var
@@ -930,8 +921,7 @@ class GenericISA(ISA):
                 )
 
     def register_value_comparator(self, comp):
-        """ """
         raise NotImplementedError
 
-    def randomize_register(self, register, seed=None):
+    def randomize_register(self, register: Register, seed=None):
         raise NotImplementedError

--- a/src/microprobe/target/isa/__init__.py
+++ b/src/microprobe/target/isa/__init__.py
@@ -51,14 +51,11 @@ import six
 
 # Local modules
 
-
 # Constants
-SCHEMA = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "schemas", "isa.yaml"
-)
-DEFAULT_ISA = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "default", "isa.yaml"
-)
+SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
+                      "isa.yaml")
+DEFAULT_ISA = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                           "default", "isa.yaml")
 LOG = get_logger(__name__)
 __all__ = [
     "find_isa_definitions", "import_isa_definition", "ISA", "GenericISA"
@@ -136,38 +133,30 @@ def _read_yaml_definition(isadefs, path):
                         else:
                             if override:
                                 complete_isadef[key][key2] = [
-                                    os.path.join(
-                                        isadef["Path"], val[key2]
-                                    )
+                                    os.path.join(isadef["Path"], val[key2])
                                 ]
                             else:
                                 complete_isadef[key][key2].append(
-                                    os.path.join(
-                                        isadef["Path"], val[key2]
-                                    )
-                                )
+                                    os.path.join(isadef["Path"], val[key2]))
 
                         if inherit:
                             key3 = "%s_inherits" % key2
                             if key3 not in complete_isadef[key]:
                                 complete_isadef[key][key3] = []
                             complete_isadef[key][key3].append(
-                                complete_isadef[key][key2][-1]
-                            )
+                                complete_isadef[key][key2][-1])
 
                     elif key2 == "Module":
                         if val[key2].startswith("microprobe"):
-                            val[key2] = os.path.join(
-                                os.path.dirname(__file__), "..", "..", "..",
-                                val[key2]
-                            )
+                            val[key2] = os.path.join(os.path.dirname(__file__),
+                                                     "..", "..", "..",
+                                                     val[key2])
 
                         if os.path.isabs(val[key2]):
                             complete_isadef[key][key2] = val[key2]
                         else:
                             complete_isadef[key][key2] = os.path.join(
-                                isadef["Path"], val[key2]
-                            )
+                                isadef["Path"], val[key2])
                     else:
                         complete_isadef[key][key2] = val[key2]
 
@@ -189,89 +178,62 @@ def import_isa_definition(path):
 
     isadef = _read_yaml_definition([], path)
 
-    regts, force = import_definition(
-        isadef, os.path.join(path, "isa.yaml"), "Register_type",
-        register_type_mod, None
-    )
+    regts, force = import_definition(isadef, os.path.join(path, "isa.yaml"),
+                                     "Register_type", register_type_mod, None)
     regts = dict2OrderedDict(regts)
 
-    regs, force = import_definition(
-        isadef,
-        os.path.join(
-            path, "isa.yaml"
-        ),
-        "Register",
-        register_mod,
-        regts,
-        force=force
-    )
+    regs, force = import_definition(isadef,
+                                    os.path.join(path, "isa.yaml"),
+                                    "Register",
+                                    register_mod,
+                                    regts,
+                                    force=force)
     regs = dict2OrderedDict(regs)
 
-    ops, force = import_operand_definition(
-        isadef,
-        os.path.join(
-            path, "isa.yaml"
-        ),
-        "Operand",
-        operand_mod,
-        regs,
-        force=force
-    )
+    ops, force = import_operand_definition(isadef,
+                                           os.path.join(path, "isa.yaml"),
+                                           "Operand",
+                                           operand_mod,
+                                           regs,
+                                           force=force)
     ops = dict2OrderedDict(ops)
 
-    ifields, force = import_definition(
-        isadef,
-        os.path.join(
-            path, "isa.yaml"
-        ),
-        "Instruction_field",
-        ifield_mod,
-        ops,
-        force=force
-    )
+    ifields, force = import_definition(isadef,
+                                       os.path.join(path, "isa.yaml"),
+                                       "Instruction_field",
+                                       ifield_mod,
+                                       ops,
+                                       force=force)
     ifields = dict2OrderedDict(ifields)
 
-    iformats, force = import_definition(
-        isadef,
-        os.path.join(
-            path, "isa.yaml"
-        ),
-        "Instruction_format",
-        iformat_mod,
-        ifields,
-        force=force
-    )
+    iformats, force = import_definition(isadef,
+                                        os.path.join(path, "isa.yaml"),
+                                        "Instruction_format",
+                                        iformat_mod,
+                                        ifields,
+                                        force=force)
 
     iformats = dict2OrderedDict(iformats)
 
-    ins, force = import_definition(
-        isadef,
-        os.path.join(
-            path, "isa.yaml"
-        ),
-        "Instruction",
-        instruction_mod, (iformats, ops),
-        force=force
-    )
+    ins, force = import_definition(isadef,
+                                   os.path.join(path, "isa.yaml"),
+                                   "Instruction",
+                                   instruction_mod, (iformats, ops),
+                                   force=force)
     ins = dict2OrderedDict(ins)
 
-    comp_clss = import_cls_definition(
-        isadef, os.path.join(path, "isa.yaml"), "Comparator", comparator_mod
-    )
+    comp_clss = import_cls_definition(isadef, os.path.join(path, "isa.yaml"),
+                                      "Comparator", comparator_mod)
 
-    gen_clss = import_cls_definition(
-        isadef, os.path.join(path, "isa.yaml"), "Generator", generator_mod
-    )
+    gen_clss = import_cls_definition(isadef, os.path.join(path, "isa.yaml"),
+                                     "Generator", generator_mod)
 
-    isa_cls = get_object_from_module(
-        isadef["ISA"]["Class"], isadef["ISA"]["Module"]
-    )
+    isa_cls = get_object_from_module(isadef["ISA"]["Class"],
+                                     isadef["ISA"]["Module"])
 
     try:
-        isa = isa_cls(
-            isadef["Name"], isadef["Description"], path, ins,
-            regs, comp_clss, gen_clss
-        )
+        isa = isa_cls(isadef["Name"], isadef["Description"], path, ins, regs,
+                      comp_clss, gen_clss)
     except TypeError as exc:
         LOG.critical("Unable to import ISA definition.")
         LOG.critical("Check if you definition is complete.")
@@ -285,14 +247,14 @@ def import_isa_definition(path):
 
     # Check definition. Ensure that all the components defined are referenced.
     for unused_regt in [
-        regt
-        for regt in regts.values()
-        if regt not in [reg.type for reg in isa.registers.values()]
+            regt for regt in regts.values()
+            if regt not in [reg.type for reg in isa.registers.values()]
     ]:
         LOG.warning("Unused register type definition: %s", unused_regt)
 
     for unused_reg in [
-        reg for reg in regs.values() if reg not in list(isa.registers.values())
+            reg for reg in regs.values()
+            if reg not in list(isa.registers.values())
     ]:
         LOG.warning("Unused register definition: %s", unused_reg)
 
@@ -306,8 +268,8 @@ def import_isa_definition(path):
             used_operands.append(field.default_operand.name)
 
     for unused_op in [
-        operand for operand in ops.values()
-        if operand.name not in used_operands
+            operand for operand in ops.values()
+            if operand.name not in used_operands
     ]:
         LOG.warning("Unused operand definition: %s", unused_op)
 
@@ -316,7 +278,8 @@ def import_isa_definition(path):
         used_fields += [field.name for field in ins.format.fields]
 
     for unused_field in [
-        field for field in ifields.values() if field.name not in used_fields
+            field for field in ifields.values()
+            if field.name not in used_fields
     ]:
         LOG.warning("Unused field definition: %s", unused_field)
 
@@ -325,8 +288,8 @@ def import_isa_definition(path):
         used_formats.append(ins.format.name)
 
     for unused_format in [
-        iformat
-        for iformat in iformats.values() if iformat.name not in used_formats
+            iformat for iformat in iformats.values()
+            if iformat.name not in used_formats
     ]:
         LOG.warning("Unused format definition: %s", unused_format)
 
@@ -357,13 +320,10 @@ def find_isa_definitions(paths=None):
             continue
 
         try:
-            definition = Definition(
-                isafile, isadef["Name"], isadef["Description"]
-            )
-            if (
-                definition not in results and
-                not definition.name.endswith("common")
-            ):
+            definition = Definition(isafile, isadef["Name"],
+                                    isadef["Description"])
+            if (definition not in results
+                    and not definition.name.endswith("common")):
                 results.append(definition)
         except TypeError as exc:
             # Skip bad definitions
@@ -537,14 +497,12 @@ class ISA(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_register_to_address(
-        self,
-        reg,
-        address,
-        context,
-        force_absolute=False,
-        force_relative=False
-    ):
+    def set_register_to_address(self,
+                                reg,
+                                address,
+                                context,
+                                force_absolute=False,
+                                force_relative=False):
         """
 
         :param reg:
@@ -723,8 +681,7 @@ class GenericISA(ISA):
         self._flag_registers = []
 
         self._scratch_var = VariableArray(
-            ("%s_scratch_var" % self._name).upper(), "char", 256, align=8
-        )
+            ("%s_scratch_var" % self._name).upper(), "char", 256, align=8)
         self._context_var = None
 
     @property
@@ -835,10 +792,8 @@ class GenericISA(ISA):
         :param context:
 
         """
-        raise MicroprobeCodeGenerationError(
-            "Unable to set register '%s' to "
-            " value '%d'." % (reg.name, value)
-        )
+        raise MicroprobeCodeGenerationError("Unable to set register '%s' to "
+                                            " value '%d'." % (reg.name, value))
 
     @property
     def scratch_registers(self):
@@ -857,16 +812,13 @@ class GenericISA(ISA):
 
         """
         reg = [
-            reg
-            for reg in self._address_registers
+            reg for reg in self._address_registers
             if reg not in context.reserved_registers
         ]
 
         if len(reg) == 0:
-            raise MicroprobeCodeGenerationError(
-                "No free registers available. "
-                "Change your policy."
-            )
+            raise MicroprobeCodeGenerationError("No free registers available. "
+                                                "Change your policy.")
 
         # REG0 tends to have special meaning and it is usually at the
         # beginning, move it
@@ -880,8 +832,7 @@ class GenericISA(ISA):
 
         """
         reg = [
-            reg
-            for reg in self._float_registers
+            reg for reg in self._float_registers
             if reg not in context.reserved_registers
         ]
 
@@ -908,18 +859,13 @@ class GenericISA(ISA):
         :param target:
 
         """
-        return super(GenericISA, self).branch_unconditional_relative(
-                source, target)
+        return super(GenericISA,
+                     self).branch_unconditional_relative(source, target)
 
     def branch_to_itself(self):
         instr = self.branch_unconditional_relative(
-            InstructionAddress(
-                base_address="code"
-            ),
-            InstructionAddress(
-                base_address="code"
-            )
-        )
+            InstructionAddress(base_address="code"),
+            InstructionAddress(base_address="code"))
         instr.set_address(None)
         return instr
 
@@ -935,8 +881,7 @@ class GenericISA(ISA):
 
         if variable.size < self.context_var.size:
             raise MicroprobeCodeGenerationError(
-                "Variable '%s' is too small to restore the target context"
-            )
+                "Variable '%s' is too small to restore the target context")
 
         asm = open(os.path.join(tmpl_path, "setcontext.S")).readlines()
         for idx, line in enumerate(asm):
@@ -947,16 +892,13 @@ class GenericISA(ISA):
 
         if complete:
             return microprobe.code.ins.instructions_from_asm(
-                asm, self.target, labels=[variable.name]
-            )
+                asm, self.target, labels=[variable.name])
         else:
             reg = self._scratch_registers[0]
-            instrs = self.set_register_to_address(
-                reg, variable.address, Context()
-            )
+            instrs = self.set_register_to_address(reg, variable.address,
+                                                  Context())
             return instrs + microprobe.code.ins.instructions_from_asm(
-                asm, self.target, labels=[variable.name]
-            )
+                asm, self.target, labels=[variable.name])
 
     def get_context(self, variable=None, tmpl_path=None, complete=False):
         """ """
@@ -966,8 +908,7 @@ class GenericISA(ISA):
 
         if variable.size < self.context_var.size:
             raise MicroprobeCodeGenerationError(
-                "Variable '%s' is too small to save the target context"
-            )
+                "Variable '%s' is too small to save the target context")
 
         asm = open(os.path.join(tmpl_path, "getcontext.S")).readlines()
         for idx, line in enumerate(asm):
@@ -978,13 +919,11 @@ class GenericISA(ISA):
 
         if complete:
             return microprobe.code.ins.instructions_from_asm(
-                asm, self.target, labels=[variable.name]
-            )
+                asm, self.target, labels=[variable.name])
         else:
             reg = self._scratch_registers[0]
-            instrs = self.set_register_to_address(
-                reg, variable.address, Context()
-            )
+            instrs = self.set_register_to_address(reg, variable.address,
+                                                  Context())
             return instrs + \
                 microprobe.code.ins.instructions_from_asm(
                     asm, self.target, labels=[variable.name]

--- a/src/microprobe/target/isa/comparator.py
+++ b/src/microprobe/target/isa/comparator.py
@@ -22,7 +22,6 @@ from __future__ import absolute_import
 import abc
 
 # Third party modules
-import six
 
 # Own modules
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError
@@ -66,7 +65,7 @@ def import_classes_from(modules):
 
 
 # Classes
-class Comparator(six.with_metaclass(abc.ABCMeta, object)):
+class Comparator(object, metaclass=abc.ABCMeta):
     """Abstract class to perform comparisons. :class:`~.Comparator`
     objects are in charge of performing comparisons between values
     while providing an architecture independent and modular interface.
@@ -126,7 +125,8 @@ class Comparator(six.with_metaclass(abc.ABCMeta, object)):
         """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def instr_name(self):
         """Value comparator name, usually the opcode of the instruction it
         uses (:class:`~.str`).

--- a/src/microprobe/target/isa/comparator.py
+++ b/src/microprobe/target/isa/comparator.py
@@ -29,7 +29,6 @@ from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.imp import find_subclasses
 from microprobe.utils.logger import get_logger
 
-
 # Constants
 LOG = get_logger(__name__)
 __all__ = ["import_classes_from", "Comparator"]
@@ -55,8 +54,7 @@ def import_classes_from(modules):
                     "Duplicated "
                     "definition"
                     " of Comparator '%s' "
-                    "in module '%s'" % (name, module_str)
-                )
+                    "in module '%s'" % (name, module_str))
             LOG.info("%s comparator imported", name)
             classes[name] = cls
 

--- a/src/microprobe/target/isa/dat.py
+++ b/src/microprobe/target/isa/dat.py
@@ -31,7 +31,6 @@ from microprobe.exceptions import MicroprobeAddressTranslationError, \
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import RejectingDict
 
-
 # Constants
 
 LOG = get_logger(__name__)
@@ -105,9 +104,8 @@ class GenericDynamicAddressTranslation(DynamicAddressTranslation):
 
     def __init__(self, target, **kwargs):
         """ """
-        super(GenericDynamicAddressTranslation, self).__init__(
-            target, **kwargs
-        )
+        super(GenericDynamicAddressTranslation,
+              self).__init__(target, **kwargs)
 
         self._map = RejectingDict()
         self._target = target
@@ -134,8 +132,7 @@ class GenericDynamicAddressTranslation(DynamicAddressTranslation):
             self._map[source & mask] = DATmap(source, target, mask)
         except MicroprobeDuplicatedValueError:
             raise MicroprobeAddressTranslationError(
-                "Map in '%s' already exists" % hex(source & mask)
-            )
+                "Map in '%s' already exists" % hex(source & mask))
 
     def copy(self, **kwargs):
         """ """
@@ -161,12 +158,10 @@ class GenericDynamicAddressTranslation(DynamicAddressTranslation):
         if len(tmap) > 1:
             raise MicroprobeAddressTranslationError(
                 "Multiple translation maps found for address '%s'" %
-                hex(address)
-            )
+                hex(address))
         elif len(tmap) < 1:
             raise MicroprobeAddressTranslationError(
-                "No translation maps found for address '%s'" % hex(address)
-            )
+                "No translation maps found for address '%s'" % hex(address))
         else:
             return tmap[0].address_translate(address, rev=rev)
 
@@ -174,15 +169,13 @@ class GenericDynamicAddressTranslation(DynamicAddressTranslation):
         """ """
         raise NotImplementedError(
             "DAT mechanisms and parameters are target dependent. Target: '%s'"
-            " does not implement them. " % self._target
-        )
+            " does not implement them. " % self._target)
 
     def raw_decorate(self, raw_str):
         """ """
         raise NotImplementedError(
             "DAT mechanisms and parameters are target dependent. Target: '%s'"
-            " does not implement them. " % self._target
-        )
+            " does not implement them. " % self._target)
 
     def required_register_values(self):
         """ """
@@ -198,8 +191,7 @@ class GenericDynamicAddressTranslation(DynamicAddressTranslation):
             if key not in self._control_keys:
                 warnings.warn(
                     "DAT Control key '%s' specified but not supported. "
-                    "Ignoring it." % key
-                )
+                    "Ignoring it." % key)
                 continue
             self._control[key] = value['value']
 
@@ -232,10 +224,8 @@ class DATmap(object):
     def address_translate(self, address, rev=False):
         if not self.address_in_map(address, rev=rev):
             raise MicroprobeAddressTranslationError(
-                "Unable to translate address '%s' in map: %s" % (
-                    hex(address), str(self)
-                )
-            )
+                "Unable to translate address '%s' in map: %s" %
+                (hex(address), str(self)))
 
         address &= (~self.mask)
         if rev:

--- a/src/microprobe/target/isa/dat.py
+++ b/src/microprobe/target/isa/dat.py
@@ -23,7 +23,6 @@ import abc
 import warnings
 
 # Third party modules
-import six
 
 # Own modules
 from microprobe.exceptions import MicroprobeAddressTranslationError, \
@@ -40,60 +39,53 @@ __all__ = ["DynamicAddressTranslation", "GenericDynamicAddressTranslation"]
 
 
 # Classes
-class DynamicAddressTranslation(six.with_metaclass(abc.ABCMeta, object)):
+class DynamicAddressTranslation(abc.ABC):
     """ """
 
     @abc.abstractmethod
     def __init__(self, target, **kwargs):
-        """ """
         pass
 
     @abc.abstractmethod
     def add_mapping(self, source, target, mask):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def maps(self):
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def control(self):
         raise NotImplementedError
 
     @abc.abstractmethod
     def copy(self, **kwargs):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def translate(self, address):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def raw_parse(self, raw_str):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def raw_decorate(self, raw_str):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def required_register_values(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def required_memory_values(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
     def update_dat(self, **kwargs):
-        """ """
         raise NotImplementedError
 
 
@@ -103,7 +95,6 @@ class GenericDynamicAddressTranslation(DynamicAddressTranslation):
     _control_keys = {'DAT': False}
 
     def __init__(self, target, **kwargs):
-        """ """
         super(GenericDynamicAddressTranslation,
               self).__init__(target, **kwargs)
 
@@ -126,7 +117,6 @@ class GenericDynamicAddressTranslation(DynamicAddressTranslation):
         return self._map
 
     def add_mapping(self, source, target, mask):
-        """ """
 
         try:
             self._map[source & mask] = DATmap(source, target, mask)
@@ -135,7 +125,6 @@ class GenericDynamicAddressTranslation(DynamicAddressTranslation):
                 "Map in '%s' already exists" % hex(source & mask))
 
     def copy(self, **kwargs):
-        """ """
 
         newargs = self.control.copy()
         newargs.update(kwargs)
@@ -145,7 +134,6 @@ class GenericDynamicAddressTranslation(DynamicAddressTranslation):
         return new_dat
 
     def translate(self, address, rev=False):
-        """ """
 
         if not self.control['DAT']:
             return address
@@ -166,27 +154,22 @@ class GenericDynamicAddressTranslation(DynamicAddressTranslation):
             return tmap[0].address_translate(address, rev=rev)
 
     def raw_parse(self, raw_str):
-        """ """
         raise NotImplementedError(
             "DAT mechanisms and parameters are target dependent. Target: '%s'"
             " does not implement them. " % self._target)
 
     def raw_decorate(self, raw_str):
-        """ """
         raise NotImplementedError(
             "DAT mechanisms and parameters are target dependent. Target: '%s'"
             " does not implement them. " % self._target)
 
     def required_register_values(self):
-        """ """
         return []
 
     def required_memory_values(self):
-        """ """
         return []
 
     def update_dat(self, **kwargs):
-        """ """
         for key, value in kwargs.items():
             if key not in self._control_keys:
                 warnings.warn(
@@ -196,7 +179,7 @@ class GenericDynamicAddressTranslation(DynamicAddressTranslation):
             self._control[key] = value['value']
 
 
-class DATmap(object):
+class DATmap:
     """ """
 
     def __init__(self, source, target, mask):

--- a/src/microprobe/target/isa/generator.py
+++ b/src/microprobe/target/isa/generator.py
@@ -29,7 +29,6 @@ from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.imp import find_subclasses
 from microprobe.utils.logger import get_logger
 
-
 # Constants
 LOG = get_logger(__name__)
 __all__ = ["import_classes_from", "Generator"]
@@ -55,8 +54,7 @@ def import_classes_from(modules):
                     "Duplicated "
                     "definition"
                     " of Generator '%s' "
-                    "in module '%s'", name, module_str
-                )
+                    "in module '%s'", name, module_str)
 
             LOG.info("%s generator imported", name)
             classes[name] = cls
@@ -92,12 +90,12 @@ class Generator(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def generate(
-        self, value,
-        fvalue, dummy_reg,
-        dummy_instr=None,
-        address=False
-    ):
+    def generate(self,
+                 value,
+                 fvalue,
+                 dummy_reg,
+                 dummy_instr=None,
+                 address=False):
         """
 
         :param value:

--- a/src/microprobe/target/isa/generator.py
+++ b/src/microprobe/target/isa/generator.py
@@ -16,18 +16,23 @@
 """
 
 # Futures
-from __future__ import absolute_import
+from __future__ import absolute_import, annotations
 
 # Built-in modules
 import abc
+from typing import TYPE_CHECKING, List
 
 # Third party modules
-import six
 
 # Own modules
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.imp import find_subclasses
 from microprobe.utils.logger import get_logger
+
+# Type hinting
+if TYPE_CHECKING:
+    from microprobe.target.isa.register import Register
+    from microprobe.code.ins import Instruction
 
 # Constants
 LOG = get_logger(__name__)
@@ -35,7 +40,7 @@ __all__ = ["import_classes_from", "Generator"]
 
 
 # Functions
-def import_classes_from(modules):
+def import_classes_from(modules: List[str]):
     """
 
     :param modules:
@@ -67,7 +72,7 @@ def import_classes_from(modules):
 
 
 # Classes
-class Generator(six.with_metaclass(abc.ABCMeta, object)):
+class Generator(abc.ABC):
     """ """
 
     def __init__(self, arch):
@@ -111,17 +116,16 @@ class Generator(six.with_metaclass(abc.ABCMeta, object)):
                                                          fvalue,
                                                          address=address))
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def instr_name(self):
-        """ """
         raise NotImplementedError
 
     @property
     def arch(self):
-        """ """
         return self._arch
 
-    def _orig_reg(self, value, reg, instr):
+    def _orig_reg(self, value, reg: Register, instr: Instruction):
         """
 
         :param value:
@@ -138,5 +142,4 @@ class Generator(six.with_metaclass(abc.ABCMeta, object)):
 
     @property
     def alias(self):  # pylint: disable=no-self-use
-        """ """
         return []

--- a/src/microprobe/target/isa/instruction.py
+++ b/src/microprobe/target/isa/instruction.py
@@ -16,7 +16,7 @@
 """
 
 # Futures
-from __future__ import absolute_import, print_function
+from __future__ import absolute_import, print_function, annotations
 
 # Built-in modules
 import abc
@@ -25,6 +25,7 @@ import os
 import random
 import sys
 from inspect import getmembers, getmodule, isfunction
+from typing import TYPE_CHECKING, List
 
 # Third party modules
 import six
@@ -42,6 +43,11 @@ from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import OrderedDict, getnextf
 from microprobe.utils.yaml import read_yaml
 
+# Type hinting
+if TYPE_CHECKING:
+    from microprobe.target.isa.register import Register
+    from microprobe.target.isa.operand import Operand
+
 # Constants
 SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
                       "instruction.yaml")
@@ -53,7 +59,7 @@ __all__ = [
 
 
 # Functions
-def import_definition(cls, filenames, args):
+def import_definition(cls, filenames: List[str], args):
     """
 
     :param filenames:
@@ -1000,13 +1006,11 @@ def _check_memops_overlap(instruction, overlap_type, condition):
     operand2 = instruction.memory_operands()[1]
 
     def function_unset_operand1():
-        """ """
         operand2.unset_possible_addresses()
         operand2.unset_possible_lengths()
         operand2.unset_forbidden_address_range()
 
     def function_unset_operand2():
-        """ """
         operand1.unset_possible_addresses()
         operand1.unset_possible_lengths()
         operand1.unset_forbidden_address_range()
@@ -1304,62 +1308,61 @@ class InstructionType(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
 
     @abc.abstractmethod
     def __init__(self):
-        """ """
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def name(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def description(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def mnemonic(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def opcode(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def format(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def operands(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def memory_operand_descriptors(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def operand_descriptors(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def implicit_operands(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def target_checks(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def instruction_checks(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -1556,62 +1559,50 @@ class GenericInstructionType(InstructionType):
 
     @property
     def name(self):
-        """ """
         return self._name
 
     @property
     def mnemonic(self):
-        """ """
         return self._mnemonic
 
     @property
     def description(self):
-        """ """
         return self._descr
 
     @property
     def opcode(self):
-        """ """
         return self._opcode
 
     @property
     def operands(self):
-        """ """
         return self._operands
 
     @property
     def memory_operand_descriptors(self):
-        """ """
         return self._memoperands
 
     @property
     def operand_descriptors(self):
-        """ """
         return self._operand_descriptors
 
     @property
     def implicit_operands(self):
-        """ """
         return self._ioperands
 
     @property
     def format(self):
-        """ """
         return self._format
 
     @property
     def instruction_checks(self):
-        """ """
         return self._instruction_checks
 
     @property
     def target_checks(self):
-        """ """
         return self._target_checks
 
     @property
     def bit_mask(self):
-        """ """
         if self._mask is None:
             self._compute_mask()
         return self._mask
@@ -1949,7 +1940,6 @@ class GenericInstructionType(InstructionType):
         return self.name >= other.name
 
     def full_report(self, tabs=0):
-        """ """
 
         shift = ("\t" * (tabs + 1))
         fmt = "%-17s : %-30s\n"

--- a/src/microprobe/target/isa/instruction.py
+++ b/src/microprobe/target/isa/instruction.py
@@ -42,16 +42,14 @@ from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import OrderedDict, getnextf
 from microprobe.utils.yaml import read_yaml
 
-
 # Constants
-SCHEMA = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "schemas", "instruction.yaml"
-)
+SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
+                      "instruction.yaml")
 LOG = get_logger(__name__)
-__all__ = ["import_definition",
-           "InstructionType",
-           "GenericInstructionType",
-           "instruction_type_from_bin"]
+__all__ = [
+    "import_definition", "InstructionType", "GenericInstructionType",
+    "instruction_type_from_bin"
+]
 
 
 # Functions
@@ -96,46 +94,36 @@ def import_definition(cls, filenames, args):
                     "instruction "
                     "definition "
                     "'%s' found "
-                    "in '%s'" % (
-                        elem["Format"], name, filename
-                    )
-                )
+                    "in '%s'" % (elem["Format"], name, filename))
 
-            operands = _merge_operands(
-                name, filename, operands, iformat, defined_operands
-            )
+            operands = _merge_operands(name, filename, operands, iformat,
+                                       defined_operands)
 
-            ioperands = _translate_ioperands(
-                name, filename, ioperands, defined_operands
-            )
+            ioperands = _translate_ioperands(name, filename, ioperands,
+                                             defined_operands)
 
-            moperands = _translate_moperands(
-                name, filename, operands, ioperands, moperands,
-                defined_memory_operands, iformat
-            )
+            moperands = _translate_moperands(name, filename, operands,
+                                             ioperands, moperands,
+                                             defined_memory_operands, iformat)
 
             # target_checks = _translate_callbacks(name, filename,
             #                                                target_checks)
 
-            instruction_checks = _translate_checks(
-                name, filename, cls, instruction_checks, operands
-            )
+            instruction_checks = _translate_checks(name, filename, cls,
+                                                   instruction_checks,
+                                                   operands)
 
-            instruction = cls(
-                name, mnemonic, opcode, descr, iformat, operands, ioperands,
-                moperands, instruction_checks, target_checks
-            )
+            instruction = cls(name, mnemonic, opcode, descr, iformat, operands,
+                              ioperands, moperands, instruction_checks,
+                              target_checks)
 
             if name in instructions:
-                raise MicroprobeArchitectureDefinitionError(
-                    "Duplicated "
-                    "definition "
-                    "of instruction "
-                    " '%s' found "
-                    "in '%s'" % (
-                        name, filename
-                    )
-                )
+                raise MicroprobeArchitectureDefinitionError("Duplicated "
+                                                            "definition "
+                                                            "of instruction "
+                                                            " '%s' found "
+                                                            "in '%s'" %
+                                                            (name, filename))
 
             LOG.debug(instruction)
             instructions[name] = instruction
@@ -158,26 +146,15 @@ def instruction_type_from_bin(binstr, target):
     """
 
     foperand = OperandConst("raw", "raw", int(binstr, 16))
-    fields = [GenericInstructionField(
-        "raw", "raw", len(binstr) * 4, False, '?', foperand)]
-    iformat = GenericInstructionFormat(
-        "raw",
-        "raw",
-        fields,
-        "raw: 0x%s" %
-        binstr)
-    instr_type = GenericInstructionType(
-        "raw",
-        "raw",
-        "0",
-        "Unknown raw code",
-        iformat,
-        {'raw': [foperand, '?']},
-        {},
-        [],
-        {},
-        {}
-    )
+    fields = [
+        GenericInstructionField("raw", "raw",
+                                len(binstr) * 4, False, '?', foperand)
+    ]
+    iformat = GenericInstructionFormat("raw", "raw", fields,
+                                       "raw: 0x%s" % binstr)
+    instr_type = GenericInstructionType("raw", "raw", "0", "Unknown raw code",
+                                        iformat, {'raw': [foperand, '?']}, {},
+                                        [], {}, {})
 
     for prop in target.nop().properties.values():
 
@@ -224,18 +201,14 @@ def _translate_checks(name, filename, cls, checks, dummy_operands):
                 "requires the "
                 "definition of '%s' "
                 "in '%s' module with "
-                "operands '%s'." % (
-                    name, filename, fname, module_filename, fargs
-                )
-            )
+                "operands '%s'." %
+                (name, filename, fname, module_filename, fargs))
 
     return dict(translated_checks)
 
 
-def _translate_moperands(
-    name, filename, operands, ioperands, moperands, defined_memory_operands,
-    iformat
-):
+def _translate_moperands(name, filename, operands, ioperands, moperands,
+                         defined_memory_operands, iformat):
     """
 
     :param name:
@@ -267,8 +240,8 @@ def _translate_moperands(
                 ]
 
                 vfield = [
-                    tfield.name
-                    for tfield in iformat.fields if tfield.name.startswith("D")
+                    tfield.name for tfield in iformat.fields
+                    if tfield.name.startswith("D")
                 ]
 
                 assert sorted(voperands) == sorted(vfield)
@@ -291,20 +264,14 @@ def _translate_moperands(
                     else:
 
                         number = set(
-                            [
-                                elem[-1] for elem in formula if elem != "D?"
-                            ]
-                        )
+                            [elem[-1] for elem in formula if elem != "D?"])
 
                         if len(number) != 1:
                             raise MicroprobeArchitectureDefinitionError(
                                 "Bad formula in name '%s' in memory operand"
                                 " '%s' of instruction '%s' (%s) in filename "
-                                "'%s'" % (
-                                    field, memoperand, name, iformat.name,
-                                    filename
-                                )
-                            )
+                                "'%s'" % (field, memoperand, name,
+                                          iformat.name, filename))
                         number = number.pop()
                         sformula.append("D%s" % number)
 
@@ -319,8 +286,7 @@ def _translate_moperands(
             if field.startswith('@'):
                 try:
                     field = [
-                        elem
-                        for elem in operands.keys()
+                        elem for elem in operands.keys()
                         if elem[0] == field[1] and elem[-3:] == field[-3:]
                     ][0]
                 except IndexError:
@@ -339,19 +305,16 @@ def _translate_moperands(
                 raise MicroprobeArchitectureDefinitionError(
                     "Unknown field name '%s' in memory operand"
                     " '%s' of instruction '%s' (%s) in filename '%s'" %
-                    (field, memoperand, name, iformat.name, filename)
-                )
+                    (field, memoperand, name, iformat.name, filename))
 
         for idx, field in enumerate(length):
             fname = "no_field_%s" % idx
             if isinstance(field, six.integer_types):
                 tlength.append((fname, field))
-            elif (
-                field.startswith("#") or field.startswith("min") or
-                field.startswith("max") or field.startswith("*") or
-                field.startswith("CEIL") or field == "Unknown" or
-                field.startswith("+") or field.startswith("-")
-            ):
+            elif (field.startswith("#") or field.startswith("min")
+                  or field.startswith("max") or field.startswith("*")
+                  or field.startswith("CEIL") or field == "Unknown"
+                  or field.startswith("+") or field.startswith("-")):
                 tlength.append((fname, field))
             else:
 
@@ -374,18 +337,15 @@ def _translate_moperands(
                         raise MicroprobeArchitectureDefinitionError(
                             "Unknown field name '%s' in length of "
                             "memory operand '%s' of instruction '%s' in"
-                            " filename '%s'" % (
-                                field, memoperand, name, filename
-                            )
-                        )
+                            " filename '%s'" %
+                            (field, memoperand, name, filename))
 
-        memory_operand = MemoryOperand(
-            OrderedDict(tformula), OrderedDict(tlength)
-        )
+        memory_operand = MemoryOperand(OrderedDict(tformula),
+                                       OrderedDict(tlength))
 
         is_defined = [
-            operand
-            for operand in defined_memory_operands if operand == memory_operand
+            operand for operand in defined_memory_operands
+            if operand == memory_operand
         ]
 
         if len(is_defined) > 0:
@@ -394,10 +354,7 @@ def _translate_moperands(
             defined_memory_operands.append(memory_operand)
 
         roperands.append(
-            MemoryOperandDescriptor(
-                memory_operand, io_flags, rate
-            )
-        )
+            MemoryOperandDescriptor(memory_operand, io_flags, rate))
 
     return roperands
 
@@ -421,10 +378,8 @@ def _translate_ioperands(name, filename, ioperands, defined_operands):
         except KeyError:
             raise MicroprobeArchitectureDefinitionError(
                 "Unknown operand name '%s' in definition "
-                "of instruction '%s' in filename '%s'" % (
-                    operand_name, name, filename
-                )
-            )
+                "of instruction '%s' in filename '%s'" %
+                (operand_name, name, filename))
 
         try:
             if operand.constant:
@@ -437,18 +392,15 @@ def _translate_ioperands(name, filename, ioperands, defined_operands):
         except IndexError:
             raise MicroprobeArchitectureDefinitionError(
                 "Unknown constant register value '%s' in definition "
-                "of instruction '%s' in filename '%s'" % (
-                    regname, name, filename
-                )
-            )
+                "of instruction '%s' in filename '%s'" %
+                (regname, name, filename))
 
         try:
             operand = defined_operands[reg.name]
         except KeyError:
-            operand = OperandConstReg(
-                "ConstantReg-%s" % reg.name, "Constant register %s" % reg.name,
-                reg, False, False, False, False
-            )
+            operand = OperandConstReg("ConstantReg-%s" % reg.name,
+                                      "Constant register %s" % reg.name, reg,
+                                      False, False, False, False)
             LOG.debug("Operand added: %s", operand)
             defined_operands[reg.name] = operand
 
@@ -456,14 +408,12 @@ def _translate_ioperands(name, filename, ioperands, defined_operands):
             raise MicroprobeArchitectureDefinitionError(
                 "Implicit operand defined but it is not constant in"
                 " definition of instruction '%s' in filename '%s'" %
-                (name, filename)
-            )
+                (name, filename))
 
         # TODO: This can be improved, we can recycle operand
         # descriptors if operand and I/O are the same
-        roperands[regname] = OperandDescriptor(
-            operand, "I" in io_def, "O" in io_def
-        )
+        roperands[regname] = OperandDescriptor(operand, "I" in io_def, "O"
+                                               in io_def)
 
     return roperands
 
@@ -495,8 +445,7 @@ def _merge_operands(name, filename, loperands, iformat, defined_operands):
         if field_name not in roperands:
 
             field_names = [
-                field
-                for field in roperands.keys()
+                field for field in roperands.keys()
                 if field.split("_")[0] == field_name
                 # if field.startswith(field_name)
             ]
@@ -505,8 +454,7 @@ def _merge_operands(name, filename, loperands, iformat, defined_operands):
                 LOG.debug("Fields: %s", roperands.keys())
                 raise MicroprobeArchitectureDefinitionError(
                     "Unknown instruction field '%s' in instruction definition"
-                    " '%s' found in '%s'" % (field_name, name, filename)
-                )
+                    " '%s' found in '%s'" % (field_name, name, filename))
             elif len(field_names) > 1:
                 raise MicroprobeArchitectureDefinitionError(
                     "Multiple matches for instruction field '%s' in "
@@ -518,9 +466,8 @@ def _merge_operands(name, filename, loperands, iformat, defined_operands):
 
         # Fix names referring to original operands
         if operand_name.startswith("@ORIG@"):
-            operand_name = operand_name.replace(
-                "@ORIG@", roperands[field_name][0].name
-            )
+            operand_name = operand_name.replace("@ORIG@",
+                                                roperands[field_name][0].name)
 
         try:
             operand = defined_operands[operand_name]
@@ -536,26 +483,22 @@ def _merge_operands(name, filename, loperands, iformat, defined_operands):
                 constant_value = None
 
             if constant_value is not None:
-                operand = OperandConst(
-                    "Constant-%s" % operand_name,
-                    "Constant value %s" % operand_name, constant_value
-                )
+                operand = OperandConst("Constant-%s" % operand_name,
+                                       "Constant value %s" % operand_name,
+                                       constant_value)
                 defined_operands[operand_name] = operand
                 LOG.debug("Operand added: %s", operand)
             else:
                 raise MicroprobeArchitectureDefinitionError(
                     "Unknown instruction operand '%s' in "
                     "instruction definition '%s' found in '%s'" %
-                    (operand_name, name, filename)
-                )
+                    (operand_name, name, filename))
 
         if field_name in fields_processed:
             raise MicroprobeArchitectureDefinitionError(
                 "Field '%s' processed twice. Check definition"
-                " instruction '%s' in file '%s'" % (
-                    field_name, name, filename
-                )
-            )
+                " instruction '%s' in file '%s'" %
+                (field_name, name, filename))
 
         roperands[field_name] = [operand, field_io]
         fields_processed.append(field_name)
@@ -588,8 +531,7 @@ def _check_reg_value(instruction, register_name, value, condition):
         if context.register_has_value(value):
 
             registers = [
-                register
-                for register in context.registers_get_value(value)
+                register for register in context.registers_get_value(value)
                 if register in context.reserved_registers
             ]
 
@@ -630,17 +572,15 @@ def _check_reg_value(instruction, register_name, value, condition):
         assert operand.is_input and not operand.is_output
 
         registers = [
-            reg
-            for reg in valid_values
-            if reg in building_block.context.reserved_registers and
-            building_block.context.get_register_value(reg) != value
+            reg for reg in valid_values
+            if reg in building_block.context.reserved_registers
+            and building_block.context.get_register_value(reg) != value
         ]
 
         if len(registers) == 0:
 
             valid_registers = [
-                reg
-                for reg in valid_values
+                reg for reg in valid_values
                 if reg not in building_block.context.reserved_registers
             ]
 
@@ -651,9 +591,8 @@ def _check_reg_value(instruction, register_name, value, condition):
             while random_value == value:
                 random_value = random.randint(0, (2**(register.type.size - 1)))
 
-            instructions = target.set_register(
-                register, random_value, building_block.context
-            )
+            instructions = target.set_register(register, random_value,
+                                               building_block.context)
 
             building_block.context.add_reserved_registers([register])
             building_block.context.set_register_value(register, random_value)
@@ -679,17 +618,15 @@ def _check_reg_value(instruction, register_name, value, condition):
         if not building_block.context.register_has_value(value):
 
             valid_registers = [
-                reg
-                for reg in valid_values
+                reg for reg in valid_values
                 if reg not in building_block.context.reserved_registers
             ]
 
             assert len(valid_registers) > 0
             register = valid_registers[0]
 
-            instructions = target.set_register(
-                register, value, building_block.context
-            )
+            instructions = target.set_register(register, value,
+                                               building_block.context)
 
             building_block.context.add_reserved_registers([register])
             building_block.context.set_register_value(register, value)
@@ -711,14 +648,12 @@ def _check_reg_value(instruction, register_name, value, condition):
 
     if condition is False:
 
-        instruction.register_context_callback(
-            key, checking_function_false, fixing_function_false
-        )
+        instruction.register_context_callback(key, checking_function_false,
+                                              fixing_function_false)
     else:
 
-        instruction.register_context_callback(
-            key, checking_function_true, fixing_function_true
-        )
+        instruction.register_context_callback(key, checking_function_true,
+                                              fixing_function_true)
 
 
 def _check_reg_bit_value(instruction, register_name, bit, value, condition):
@@ -778,9 +713,8 @@ def _check_reg_bit_value(instruction, register_name, bit, value, condition):
         """
 
         register = target.registers[register_name]
-        instructions = target.set_register_bits(
-            register, value, mask, shift, building_block.context
-        )
+        instructions = target.set_register_bits(register, value, mask, shift,
+                                                building_block.context)
 
         if register not in building_block.context.reserved_registers:
             building_block.context.add_reserved_registers([register])
@@ -788,14 +722,12 @@ def _check_reg_bit_value(instruction, register_name, bit, value, condition):
         building_block.context.set_register_value(register, cannary_value)
         building_block.add_init(instructions)
 
-    instruction.register_context_callback(
-        key, checking_function, fixing_function
-    )
+    instruction.register_context_callback(key, checking_function,
+                                          fixing_function)
 
 
-def _check_operands(
-    instruction, operand1_name, operand2_name, check_type, condition
-):
+def _check_operands(instruction, operand1_name, operand2_name, check_type,
+                    condition):
     """
 
     :param instruction:
@@ -847,13 +779,10 @@ def _check_operands(
                 new_type_operand2.set_valid_values([value])
                 assert list(new_type_operand2.values()) == [value]
             else:
-                new_type_operand2.set_valid_values(
-                    [
-                        elem
-                        for elem in orig_descriptor_operand2.type.values(
-                        ) if elem != value
-                    ]
-                )
+                new_type_operand2.set_valid_values([
+                    elem for elem in orig_descriptor_operand2.type.values()
+                    if elem != value
+                ])
 
             # LOG.debug("Orig operand 2 values: %s",
             #          orig_descriptor_operand2.type.values())
@@ -862,19 +791,14 @@ def _check_operands(
             LOG.debug(
                 "Removed from orig: %s",
                 set(orig_descriptor_operand2.type.values()) -
-                set(new_type_operand2.values())
-            )
+                set(new_type_operand2.values()))
 
-            LOG.debug(
-                "Removed from previous: %s",
-                set(previous_values) - set(new_type_operand2.values())
-            )
+            LOG.debug("Removed from previous: %s",
+                      set(previous_values) - set(new_type_operand2.values()))
 
             assert len(
-                set(new_type_operand2.values()) - set(
-                    orig_descriptor_operand2.type.values()
-                )
-            ) == 0
+                set(new_type_operand2.values()) -
+                set(orig_descriptor_operand2.type.values())) == 0
 
         def function_set_operand2(value):
             """
@@ -899,13 +823,10 @@ def _check_operands(
             if condition:
                 new_type_operand1.set_valid_values([value])
             else:
-                new_type_operand1.set_valid_values(
-                    [
-                        elem
-                        for elem in orig_descriptor_operand1.type.values(
-                        ) if elem != value
-                    ]
-                )
+                new_type_operand1.set_valid_values([
+                    elem for elem in orig_descriptor_operand1.type.values()
+                    if elem != value
+                ])
 
             # LOG.debug("Orig operand 1 values: %s",
             #          orig_descriptor_operand1.type.values())
@@ -914,19 +835,14 @@ def _check_operands(
             LOG.debug(
                 "Removed from orig: %s",
                 set(orig_descriptor_operand1.type.values()) -
-                set(new_type_operand1.values())
-            )
+                set(new_type_operand1.values()))
 
-            LOG.debug(
-                "Removed from previous: %s",
-                set(previous_values) - set(new_type_operand1.values())
-            )
+            LOG.debug("Removed from previous: %s",
+                      set(previous_values) - set(new_type_operand1.values()))
 
             assert len(
-                set(new_type_operand1.values()) - set(
-                    orig_descriptor_operand1.type.values()
-                )
-            ) == 0
+                set(new_type_operand1.values()) -
+                set(orig_descriptor_operand1.type.values())) == 0
 
         def function_unset_operand1():
             """ """
@@ -936,13 +852,11 @@ def _check_operands(
             """ """
             operand1.set_descriptor(orig_descriptor_operand1)
 
-        operand1.register_operand_callbacks(
-            function_set_operand1, function_unset_operand1
-        )
+        operand1.register_operand_callbacks(function_set_operand1,
+                                            function_unset_operand1)
 
-        operand2.register_operand_callbacks(
-            function_set_operand2, function_unset_operand2
-        )
+        operand2.register_operand_callbacks(function_set_operand2,
+                                            function_unset_operand2)
     elif check_type == "less":
 
         new_base_descriptor_operand1 = operand1.descriptor.copy()
@@ -956,35 +870,23 @@ def _check_operands(
         # used
         operand1.set_descriptor(new_base_descriptor_operand1)
         new_base_descriptor_operand1.set_type(new_base_type_operand1)
-        new_base_type_operand1.set_valid_values(
-            [
-                elem
-                for elem in orig_descriptor_operand1.type.values()
-                if len(
-                    [
-                        value for value in
-                        orig_descriptor_operand2.type.values() if value > elem
-                    ]
-                ) > 0
-            ]
-        )
+        new_base_type_operand1.set_valid_values([
+            elem for elem in orig_descriptor_operand1.type.values() if len([
+                value for value in orig_descriptor_operand2.type.values()
+                if value > elem
+            ]) > 0
+        ])
 
         orig_descriptor_operand1 = operand1.descriptor
 
         operand2.set_descriptor(new_base_descriptor_operand2)
         new_base_descriptor_operand2.set_type(new_base_type_operand2)
-        new_base_type_operand2.set_valid_values(
-            [
-                elem
-                for elem in orig_descriptor_operand2.type.values()
-                if len(
-                    [
-                        value for value in
-                        orig_descriptor_operand1.type.values() if value < elem
-                    ]
-                ) > 0
-            ]
-        )
+        new_base_type_operand2.set_valid_values([
+            elem for elem in orig_descriptor_operand2.type.values() if len([
+                value for value in orig_descriptor_operand1.type.values()
+                if value < elem
+            ]) > 0
+        ])
 
         orig_descriptor_operand2 = operand2.descriptor
 
@@ -1016,19 +918,15 @@ def _check_operands(
 
             previous_values = set(new_type_operand2.values())
 
-            new_type_operand2.set_valid_values(
-                [
-                    elem
-                    for elem in orig_descriptor_operand2.type.values(
-                    ) if elem > value
-                ]
-            )
+            new_type_operand2.set_valid_values([
+                elem for elem in orig_descriptor_operand2.type.values()
+                if elem > value
+            ])
 
             new_values = set(new_type_operand2.values())
 
-            LOG.debug(
-                "Operand '%s' values: %s", operand2_name, previous_values
-            )
+            LOG.debug("Operand '%s' values: %s", operand2_name,
+                      previous_values)
             LOG.debug("Operand '%s' new values: %s", operand2_name, new_values)
             LOG.debug("Operand differences: %s", previous_values - new_values)
 
@@ -1054,19 +952,15 @@ def _check_operands(
 
             previous_values = set(new_type_operand1.values())
 
-            new_type_operand1.set_valid_values(
-                [
-                    elem
-                    for elem in orig_descriptor_operand1.type.values(
-                    ) if elem < value
-                ]
-            )
+            new_type_operand1.set_valid_values([
+                elem for elem in orig_descriptor_operand1.type.values()
+                if elem < value
+            ])
 
             new_values = set(new_type_operand1.values())
 
-            LOG.debug(
-                "Operand '%s' values: %s", operand1_name, previous_values
-            )
+            LOG.debug("Operand '%s' values: %s", operand1_name,
+                      previous_values)
             LOG.debug("Operand '%s' new values: %s", operand1_name, new_values)
             LOG.debug("Operand differences: %s", previous_values - new_values)
 
@@ -1078,19 +972,16 @@ def _check_operands(
             """ """
             operand1.set_descriptor(orig_descriptor_operand1)
 
-        operand1.register_operand_callbacks(
-            function_set_operand1, function_unset_operand1
-        )
+        operand1.register_operand_callbacks(function_set_operand1,
+                                            function_unset_operand1)
 
-        operand2.register_operand_callbacks(
-            function_set_operand2, function_unset_operand2
-        )
+        operand2.register_operand_callbacks(function_set_operand2,
+                                            function_unset_operand2)
 
     else:
 
-        raise NotImplementedError(
-            "Condition '%s' not implemented" % check_type
-        )
+        raise NotImplementedError("Condition '%s' not implemented" %
+                                  check_type)
 
 
 def _check_memops_overlap(instruction, overlap_type, condition):
@@ -1178,16 +1069,12 @@ def _check_memops_overlap(instruction, overlap_type, condition):
 
             if condition is True:
                 operand2.set_possible_addresses(
-                    [
-                        possible_address1, possible_address2
-                    ], context
-                )
+                    [possible_address1, possible_address2], context)
                 operand2.set_possible_lengths([operand1.length], context)
             else:
-                operand2.set_forbidden_address_range(
-                    possible_address1,
-                    possible_address2,
-                    context)
+                operand2.set_forbidden_address_range(possible_address1,
+                                                     possible_address2,
+                                                     context)
 
         def function_set_operand2(context):
             """
@@ -1201,26 +1088,22 @@ def _check_memops_overlap(instruction, overlap_type, condition):
 
             if condition is True:
                 operand1.set_possible_addresses(
-                    [
-                        possible_address1, possible_address2
-                    ], context
-                )
+                    [possible_address1, possible_address2], context)
                 operand1.set_possible_lengths([operand2.length], context)
             else:
-                operand1.set_forbidden_address_range(
-                    possible_address1,
-                    possible_address2,
-                    context)
+                operand1.set_forbidden_address_range(possible_address1,
+                                                     possible_address2,
+                                                     context)
 
-        operand1.register_mem_operand_callback(
-            function_set_operand1_address, function_set_operand1_length,
-            function_unset_operand1, function_unset_operand1
-        )
+        operand1.register_mem_operand_callback(function_set_operand1_address,
+                                               function_set_operand1_length,
+                                               function_unset_operand1,
+                                               function_unset_operand1)
 
-        operand2.register_mem_operand_callback(
-            function_set_operand2_address, function_set_operand2_length,
-            function_unset_operand2, function_unset_operand2
-        )
+        operand2.register_mem_operand_callback(function_set_operand2_address,
+                                               function_set_operand2_length,
+                                               function_unset_operand2,
+                                               function_unset_operand2)
 
     elif overlap_type == "8_bytes_destructive":
 
@@ -1236,10 +1119,7 @@ def _check_memops_overlap(instruction, overlap_type, condition):
 
             if condition is True:
                 operand2.set_possible_addresses(
-                    [
-                        possible_address1, possible_address2
-                    ], context
-                )
+                    [possible_address1, possible_address2], context)
                 operand2.set_possible_lengths([operand1.length], context)
             else:
                 raise NotImplementedError
@@ -1256,23 +1136,20 @@ def _check_memops_overlap(instruction, overlap_type, condition):
 
             if condition is True:
                 operand1.set_possible_addresses(
-                    [
-                        possible_address1, possible_address2
-                    ], context
-                )
+                    [possible_address1, possible_address2], context)
                 operand1.set_possible_lengths([operand2.length], context)
             else:
                 raise NotImplementedError
 
-        operand1.register_mem_operand_callback(
-            function_set_operand1_address, function_set_operand1_length,
-            function_unset_operand1, function_unset_operand1
-        )
+        operand1.register_mem_operand_callback(function_set_operand1_address,
+                                               function_set_operand1_length,
+                                               function_unset_operand1,
+                                               function_unset_operand1)
 
-        operand2.register_mem_operand_callback(
-            function_set_operand2_address, function_set_operand2_length,
-            function_unset_operand2, function_unset_operand2
-        )
+        operand2.register_mem_operand_callback(function_set_operand2_address,
+                                               function_set_operand2_length,
+                                               function_unset_operand2,
+                                               function_unset_operand2)
 
     elif overlap_type == "destructive_any" or \
             overlap_type == "destructive_any_or_exact" or \
@@ -1290,9 +1167,8 @@ def _check_memops_overlap(instruction, overlap_type, condition):
             assert max_address >= min_address
 
             if condition is False:
-                operand2.set_forbidden_address_range(
-                    min_address, max_address, context
-                )
+                operand2.set_forbidden_address_range(min_address, max_address,
+                                                     context)
             else:
 
                 alignment = operand2.alignment()
@@ -1300,14 +1176,10 @@ def _check_memops_overlap(instruction, overlap_type, condition):
                     alignment = 1
 
                 addresses = [
-                    operand1.address +
-                    index for index in range(
-                        max_address -
-                        min_address +
-                        1) if (
-                        operand1.address +
-                        index).displacement %
-                    alignment == 0]
+                    operand1.address + index
+                    for index in range(max_address - min_address + 1)
+                    if (operand1.address + index).displacement % alignment == 0
+                ]
 
                 if len(addresses) == 0:
                     raise NotImplementedError
@@ -1326,9 +1198,8 @@ def _check_memops_overlap(instruction, overlap_type, condition):
             assert max_address >= min_address
 
             if condition is False:
-                operand1.set_forbidden_address_range(
-                    min_address, max_address, context
-                )
+                operand1.set_forbidden_address_range(min_address, max_address,
+                                                     context)
             else:
 
                 alignment = operand2.alignment()
@@ -1336,29 +1207,25 @@ def _check_memops_overlap(instruction, overlap_type, condition):
                     alignment = 1
 
                 addresses = [
-                    operand2.address +
-                    index for index in range(
-                        max_address -
-                        min_address +
-                        1) if (
-                        operand2.address +
-                        index).displacement %
-                    alignment == 0]
+                    operand2.address + index
+                    for index in range(max_address - min_address + 1)
+                    if (operand2.address + index).displacement % alignment == 0
+                ]
 
                 if len(addresses) == 0:
                     raise NotImplementedError
 
                 operand1.set_possible_addresses(addresses, context)
 
-        operand1.register_mem_operand_callback(
-            function_set_operand1_address, function_set_operand1_length,
-            function_unset_operand1, function_unset_operand1
-        )
+        operand1.register_mem_operand_callback(function_set_operand1_address,
+                                               function_set_operand1_length,
+                                               function_unset_operand1,
+                                               function_unset_operand1)
 
-        operand2.register_mem_operand_callback(
-            function_set_operand2_address, function_set_operand2_length,
-            function_unset_operand2, function_unset_operand2
-        )
+        operand2.register_mem_operand_callback(function_set_operand2_address,
+                                               function_set_operand2_length,
+                                               function_unset_operand2,
+                                               function_unset_operand2)
 
     elif overlap_type == "exact":
 
@@ -1392,15 +1259,15 @@ def _check_memops_overlap(instruction, overlap_type, condition):
             else:
                 raise NotImplementedError
 
-        operand1.register_mem_operand_callback(
-            function_set_operand1_address, function_set_operand1_length,
-            function_unset_operand1, function_unset_operand1
-        )
+        operand1.register_mem_operand_callback(function_set_operand1_address,
+                                               function_set_operand1_length,
+                                               function_unset_operand1,
+                                               function_unset_operand1)
 
-        operand2.register_mem_operand_callback(
-            function_set_operand2_address, function_set_operand2_length,
-            function_unset_operand2, function_unset_operand2
-        )
+        operand2.register_mem_operand_callback(function_set_operand2_address,
+                                               function_set_operand2_length,
+                                               function_unset_operand2,
+                                               function_unset_operand2)
 
     else:
         # print(overlap_type, condition)
@@ -1425,11 +1292,8 @@ def _check_alignment(instruction, operand_idx, alignment):
 
 
 GENERIC_INSTRUCTION_CHECKS = {}
-for _key, _value in dict(
-    getmembers(
-        sys.modules[__name__], isfunction
-    )
-).items():
+for _key, _value in dict(getmembers(sys.modules[__name__],
+                                    isfunction)).items():
     if _key.startswith("_check_"):
         GENERIC_INSTRUCTION_CHECKS[_key[1:]] = _value
 
@@ -1566,10 +1430,8 @@ class GenericInstructionType(InstructionType):
 
     """
 
-    def __init__(
-        self, name, mnemonic, opcode, descr, iformat, operands, ioperands,
-        moperands, instruction_checks, target_checks
-    ):
+    def __init__(self, name, mnemonic, opcode, descr, iformat, operands,
+                 ioperands, moperands, instruction_checks, target_checks):
         """
 
         :param name:
@@ -1604,8 +1466,7 @@ class GenericInstructionType(InstructionType):
                 raise MicroprobeArchitectureDefinitionError(
                     "Inconsistent instruction definition. "
                     "Each instruction field should have an operand. "
-                    "Instruction: %s", self.name
-                )
+                    "Instruction: %s", self.name)
             else:
                 # Sort the operands
                 tmp_val = self.operands[key]
@@ -1613,29 +1474,26 @@ class GenericInstructionType(InstructionType):
                 self.operands[key] = tmp_val
 
         if list(self.operands.keys()) != [
-                field.name for field in iformat.fields]:
+                field.name for field in iformat.fields
+        ]:
             LOG.error("Operands: %s", list(self.operands.keys()))
             LOG.error("Fields: %s", [field.name for field in iformat.fields])
             LOG.error("Instruction format: %s", iformat.name)
             # print(self.operands.keys())
             # print([field.name for field in iformat.fields])
-            raise MicroprobeArchitectureDefinitionError(
-                "Operands and fields "
-                "are not aligned in "
-                "'%s'" % self.name
-            )
+            raise MicroprobeArchitectureDefinitionError("Operands and fields "
+                                                        "are not aligned in "
+                                                        "'%s'" % self.name)
 
         self._operand_descriptors = OrderedDict()
-        for op_descriptor, field in zip(
-            list(self.operands.items()), self.format.fields
-        ):
+        for op_descriptor, field in zip(list(self.operands.items()),
+                                        self.format.fields):
             fieldname, op_descriptor = op_descriptor
             operand, io_def = op_descriptor
 
             if field.name != fieldname:
                 raise MicroprobeArchitectureDefinitionError(
-                    "Operands and fields are not aligned in '%s" % self.name
-                )
+                    "Operands and fields are not aligned in '%s" % self.name)
 
             if not field.default_show:
                 continue
@@ -1644,15 +1502,13 @@ class GenericInstructionType(InstructionType):
             #     continue
 
             self._operand_descriptors[field.name] = OperandDescriptor(
-                operand, "I" in io_def, "O" in io_def
-            )
+                operand, "I" in io_def, "O" in io_def)
 
         opcode_operands = [op for op in operands if op.startswith('opcode')]
 
         if len(opcode_operands) == 1:
             self.operands[opcode_operands[0]][0] = OperandConst(
-                "Opcode", "Instruction opcode", int(self.opcode, 16)
-            )
+                "Opcode", "Instruction opcode", int(self.opcode, 16))
         else:
             # Assume the back-end will take care of multiple operands
             pass
@@ -1663,15 +1519,13 @@ class GenericInstructionType(InstructionType):
 
         mask_val_str = "0b"
         mask_str = "0b"
-        for op_descriptor, field in zip(
-            list(self.operands.items()), self.format.fields
-        ):
+        for op_descriptor, field in zip(list(self.operands.items()),
+                                        self.format.fields):
             dummy_fieldname, op_descriptor = op_descriptor
             format_str = "{0:0%db}" % field.size
 
             if op_descriptor[0].constant and op_descriptor[
-                0
-            ].immediate and not field.default_show:
+                    0].immediate and not field.default_show:
 
                 mask_val_str = mask_val_str + \
                     format_str.format(list(op_descriptor[0].values())[0])
@@ -1689,13 +1543,11 @@ class GenericInstructionType(InstructionType):
                 mask_str = mask_str + "".join(['0'] * field.size)
 
         assert len(mask_val_str) == self.format.length * 8 + 2, "%s != %s" % (
-            len(mask_val_str), self.format.length * 8 + 2
-        )
+            len(mask_val_str), self.format.length * 8 + 2)
         mask_val = int(mask_val_str, 2)
 
         assert len(mask_str) == self.format.length * 8 + 2, "%s != %s" % (
-            len(mask_str), self.format.length * 8 + 2
-        )
+            len(mask_str), self.format.length * 8 + 2)
         mask = int(mask_str, 2)
 
         assert mask != 0
@@ -1808,9 +1660,8 @@ class GenericInstructionType(InstructionType):
         LOG.debug("Assembly string: %s", format_str)
         assembly_str = format_str.replace("OPC", "@@@")
 
-        for op_descriptor, field in zip(
-            list(self.operands.items()), self.format.fields
-        ):
+        for op_descriptor, field in zip(list(self.operands.items()),
+                                        self.format.fields):
             fieldname, op_descriptor = op_descriptor
             operand, dummy = op_descriptor
 
@@ -1818,8 +1669,7 @@ class GenericInstructionType(InstructionType):
 
             if field.name != fieldname:
                 raise MicroprobeArchitectureDefinitionError(
-                    "Operands and fields are not aligned in '%s" % self.name
-                )
+                    "Operands and fields are not aligned in '%s" % self.name)
 
             if not field.default_show:
                 LOG.debug("Skip not shown")
@@ -1836,17 +1686,15 @@ class GenericInstructionType(InstructionType):
 
                 if operand.name == "Zero":  # Operand Zero never shows
                     assembly_str = assembly_str.replace(
-                        " %s," % field.name, ""
-                    )
+                        " %s," % field.name, "")
                     assembly_str = assembly_str.replace(
-                        ", %s" % field.name, ""
-                    )
+                        ", %s" % field.name, "")
                     assembly_str = assembly_str.replace("%s" % field.name, "")
                     assembly_str = assembly_str.replace("()", "")
                 else:
                     assembly_str = assembly_str.replace(
-                        field.name, next_operand_value().representation
-                    )
+                        field.name,
+                        next_operand_value().representation)
                     # operand.representation(operand.values()[0])
             else:
 
@@ -1856,98 +1704,85 @@ class GenericInstructionType(InstructionType):
 
                     assembly_str = assembly_str.replace(
                         "@@@ " + field.name + ",",
-                        "@@@ " + next_operand_value().representation + ",", 1
-                    )
+                        "@@@ " + next_operand_value().representation + ",", 1)
 
                 elif assembly_str.find(", " + field.name + ",") >= 0:
 
                     assembly_str = assembly_str.replace(
                         ", " + field.name + ",",
-                        ", " + next_operand_value().representation + ",", 1
-                    )
+                        ", " + next_operand_value().representation + ",", 1)
 
                 elif assembly_str.endswith(", " + field.name):
 
                     assembly_str = assembly_str.replace(
                         ", " + field.name,
-                        ", " + next_operand_value().representation, 1
-                    )
+                        ", " + next_operand_value().representation, 1)
 
                 elif assembly_str.find("@@@ $" + field.name + ",") >= 0:
 
                     assembly_str = assembly_str.replace(
                         "@@@ $" + field.name + ",",
-                        "@@@ $" + next_operand_value().representation + ",", 1
-                    )
+                        "@@@ $" + next_operand_value().representation + ",", 1)
 
                 elif assembly_str.find(", $" + field.name + ",") >= 0:
 
                     assembly_str = assembly_str.replace(
                         ", $" + field.name + ",",
-                        ", $" + next_operand_value().representation + ",", 1
-                    )
+                        ", $" + next_operand_value().representation + ",", 1)
 
                 elif assembly_str.endswith(", $" + field.name):
 
                     assembly_str = assembly_str.replace(
                         ", $" + field.name,
-                        ", $" + next_operand_value().representation, 1
-                    )
+                        ", $" + next_operand_value().representation, 1)
 
                 elif assembly_str.find("@@@ " + field.name) >= 0:
 
                     assembly_str = assembly_str.replace(
                         "@@@ " + field.name,
-                        "@@@ " + next_operand_value().representation, 1
-                    )
+                        "@@@ " + next_operand_value().representation, 1)
 
                 elif assembly_str.find("(" + field.name + ")") >= 0:
 
                     assembly_str = assembly_str.replace(
                         "(" + field.name + ")",
-                        "(" + next_operand_value().representation + ")", 1
-                    )
+                        "(" + next_operand_value().representation + ")", 1)
 
                 elif assembly_str.find("(" + field.name + ",") >= 0:
 
                     assembly_str = assembly_str.replace(
                         "(" + field.name + ",",
-                        "(" + next_operand_value().representation + ",", 1
-                    )
+                        "(" + next_operand_value().representation + ",", 1)
 
                 elif assembly_str.find(" " + field.name + ")") >= 0:
 
                     assembly_str = assembly_str.replace(
                         " " + field.name + ")",
-                        " " + next_operand_value().representation + ")", 1
-                    )
+                        " " + next_operand_value().representation + ")", 1)
 
                 elif assembly_str.find(" " + field.name + "(") >= 0:
 
                     assembly_str = assembly_str.replace(
                         " " + field.name + "(",
-                        " " + next_operand_value().representation + "(", 1
-                    )
+                        " " + next_operand_value().representation + "(", 1)
 
                 elif assembly_str.find("," + field.name + ")") >= 0:
 
                     assembly_str = assembly_str.replace(
                         "," + field.name + ")",
-                        "," + next_operand_value().representation + ")", 1
-                    )
+                        "," + next_operand_value().representation + ")", 1)
 
                 else:
                     LOG.debug(
-                        "%s", list(zip(
-                            list(self.operands.items()), self.format.fields
-                        ))
-                    )
+                        "%s",
+                        list(
+                            zip(list(self.operands.items()),
+                                self.format.fields)))
                     LOG.debug("Current assembly: %s", assembly_str)
 
                     raise MicroprobeArchitectureDefinitionError(
                         "Unable to generate correct assembly for '%s' "
-                        "instruction" % self.mnemonic
-                    )
+                        "instruction" % self.mnemonic)
 
             LOG.debug("Current assembly: %s", assembly_str)
 
@@ -1976,9 +1811,8 @@ class GenericInstructionType(InstructionType):
         LOG.debug("Start codification: %s", self.assembly(asm_args))
         LOG.debug("Args: %s", args)
 
-        for op_descriptor, field in zip(
-            list(self.operands.items()), self.format.fields
-        ):
+        for op_descriptor, field in zip(list(self.operands.items()),
+                                        self.format.fields):
 
             fieldname, op_descriptor = op_descriptor
             operand, dummy = op_descriptor
@@ -1989,8 +1823,7 @@ class GenericInstructionType(InstructionType):
 
             if field.name != fieldname:
                 raise MicroprobeArchitectureDefinitionError(
-                    "Operands and fields are not aligned in '%s" % self.name
-                )
+                    "Operands and fields are not aligned in '%s" % self.name)
 
             format_field_str = "{0:0%db}" % field.size
             field_length += field.size
@@ -2028,9 +1861,8 @@ class GenericInstructionType(InstructionType):
 
                 raise MicroprobeArchitectureDefinitionError(
                     "Operand value can not be codified within the "
-                    "instruction field. Operand: %s Value: %d"
-                    % (operand, opvalue)
-                )
+                    "instruction field. Operand: %s Value: %d" %
+                    (operand, opvalue))
 
             if opvalue < 0:
 
@@ -2045,9 +1877,8 @@ class GenericInstructionType(InstructionType):
 
                     raise MicroprobeArchitectureDefinitionError(
                         "Operand value can not be codified within the "
-                        "instruction field. Operand: %s Value: %d"
-                        % (operand, opvalue)
-                    )
+                        "instruction field. Operand: %s Value: %d" %
+                        (operand, opvalue))
 
                 opvalue = opvalue + 2**field.size
 
@@ -2084,11 +1915,8 @@ class GenericInstructionType(InstructionType):
 
     def _check_cmp(self, other):
         if not isinstance(other, self.__class__):
-            raise NotImplementedError(
-                "%s != %s" % (
-                    other.__class__, self.__class__
-                )
-            )
+            raise NotImplementedError("%s != %s" %
+                                      (other.__class__, self.__class__))
 
     def __eq__(self, other):
         """x.__eq__(y) <==> x==y"""

--- a/src/microprobe/target/isa/instruction_field.py
+++ b/src/microprobe/target/isa/instruction_field.py
@@ -30,12 +30,9 @@ from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.logger import get_logger
 from microprobe.utils.yaml import read_yaml
 
-
 # Constants
-SCHEMA = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "schemas",
-    "instruction_field.yaml"
-)
+SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
+                      "instruction_field.yaml")
 
 LOG = get_logger(__name__)
 __all__ = ["import_definition", "InstructionField", "GenericInstructionField"]
@@ -74,8 +71,7 @@ def import_definition(cls, filenames, operands):
                 LOG.warning(
                     "Similar definition of instruction field: '%s' and"
                     " '%s'. Check if definition needed.", name,
-                    ifields_duplicated[key]
-                )
+                    ifields_duplicated[key])
             else:
                 ifields_duplicated[key] = name
 
@@ -85,8 +81,7 @@ def import_definition(cls, filenames, operands):
                 raise MicroprobeArchitectureDefinitionError(
                     "Unknown operand "
                     "defined in instruction"
-                    " field '%s' in '%s'." % (name, filename)
-                )
+                    " field '%s' in '%s'." % (name, filename))
             ifield = cls(name, descr, size, show, fio, operand)
 
             if name in ifields:
@@ -94,8 +89,7 @@ def import_definition(cls, filenames, operands):
                     "Duplicated "
                     "definition "
                     "of instruction field"
-                    " '%s' found in '%s'" % (name, filename)
-                )
+                    " '%s' found in '%s'" % (name, filename))
 
             LOG.debug(ifield)
             ifields[name] = ifield
@@ -188,11 +182,9 @@ class GenericInstructionField(InstructionField):
         self._foperand = foperand
 
         if fio not in self._valid_fio_values:
-            raise MicroprobeArchitectureDefinitionError(
-                "Invalid default IO "
-                "definition for field "
-                "%s" % fname
-            )
+            raise MicroprobeArchitectureDefinitionError("Invalid default IO "
+                                                        "definition for field "
+                                                        "%s" % fname)
 
     @property
     def name(self):

--- a/src/microprobe/target/isa/instruction_field.py
+++ b/src/microprobe/target/isa/instruction_field.py
@@ -16,19 +16,23 @@
 """
 
 # Futures
-from __future__ import absolute_import
+from __future__ import absolute_import, annotations
 
 # Built-in modules
 import abc
 import os
+from typing import TYPE_CHECKING, Dict, List, Tuple
 
 # Third party modules
-import six
 
 # Own modules
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.logger import get_logger
 from microprobe.utils.yaml import read_yaml
+
+# Type hinting
+if TYPE_CHECKING:
+    from microprobe.target.isa.operand import Operand
 
 # Constants
 SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
@@ -39,7 +43,7 @@ __all__ = ["import_definition", "InstructionField", "GenericInstructionField"]
 
 
 # Functions
-def import_definition(cls, filenames, operands):
+def import_definition(cls, filenames: List[str], operands: Dict[str, Operand]):
     """
 
     :param filenames:
@@ -49,7 +53,7 @@ def import_definition(cls, filenames, operands):
 
     LOG.debug("Start")
     ifields = {}
-    ifields_duplicated = {}
+    ifields_duplicated: Dict[Tuple[int, bool, str, str], str] = {}
 
     for filename in filenames:
         ifield_data = read_yaml(filename, SCHEMA)
@@ -99,47 +103,45 @@ def import_definition(cls, filenames, operands):
 
 
 # Classes
-class InstructionField(six.with_metaclass(abc.ABCMeta, object)):
+class InstructionField(abc.ABC):
     """Abstract class to represent an instruction field"""
 
     @abc.abstractmethod
     def __init__(self):
-        """ """
         pass
 
-    @abc.abstractproperty
-    def name(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def description(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def description(self) -> str:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def size(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def size(self) -> int:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def default_show(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def default_show(self) -> bool:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def default_io(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def default_io(self) -> str:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def default_operand(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def default_operand(self) -> Operand:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def __str__(self):
-        """ """
+    def __str__(self) -> str:
         raise NotImplementedError
 
 
@@ -161,7 +163,8 @@ class GenericInstructionField(InstructionField):
 
     _valid_fio_values = ['I', 'O', 'IO', '?']
 
-    def __init__(self, fname, descr, fsize, fshow, fio, foperand):
+    def __init__(self, fname: str, descr: str, fsize: int, fshow: bool,
+                 fio: str, foperand: Operand):
         """
 
         :param fname:
@@ -182,44 +185,35 @@ class GenericInstructionField(InstructionField):
         self._foperand = foperand
 
         if fio not in self._valid_fio_values:
-            raise MicroprobeArchitectureDefinitionError("Invalid default IO "
-                                                        "definition for field "
-                                                        "%s" % fname)
+            raise MicroprobeArchitectureDefinitionError(
+                f"Invalid default IO definition for field {fname}")
 
     @property
     def name(self):
-        """ """
         return self._fname
 
     @property
     def description(self):
-        """ """
         return self._fdescr
 
     @property
     def size(self):
-        """ """
         return self._fsize
 
     @property
     def default_show(self):
-        """ """
         return self._fshow
 
     @property
     def default_operand(self):
-        """ """
         return self._foperand
 
     @property
     def default_io(self):
-        """ """
         return self._fio
 
     def __str__(self):
-        """ """
         return "%10s : %s" % (self.name, self.description)
 
     def __repr__(self):
-        """ """
         return "%s('%s')" % (self.__class__.__name__, self.name)

--- a/src/microprobe/target/isa/instruction_format.py
+++ b/src/microprobe/target/isa/instruction_format.py
@@ -16,20 +16,24 @@
 """
 
 # Futures
-from __future__ import absolute_import, division
+from __future__ import absolute_import, division, annotations
 
 # Built-in modules
 import abc
 import os
+from typing import TYPE_CHECKING, List, Tuple
 
 # Third party modules
-import six
 
 # Own modules
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError, \
     MicroprobeLookupError
 from microprobe.utils.logger import get_logger
 from microprobe.utils.yaml import read_yaml
+
+# Type hinting
+if TYPE_CHECKING:
+    from microprobe.target.isa.instruction_field import InstructionField
 
 # Constants
 SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
@@ -41,7 +45,7 @@ __all__ = [
 
 
 # Functions
-def import_definition(cls, filenames, ifields):
+def import_definition(cls, filenames: List[str], ifields):
     """
 
     :param filenames:
@@ -82,31 +86,22 @@ def import_definition(cls, filenames, ifields):
             if len(nonzero_fields) != len(set(nonzero_fields)):
 
                 raise MicroprobeArchitectureDefinitionError(
-                    "Definition of "
-                    "instruction format"
-                    " '%s' found in '%s'"
-                    " contains duplicated"
-                    " fields." % (name, filename))
+                    f"Definition of instruction format '{name}' found in "
+                    f"'{filename}' contains duplicated fields.")
 
             try:
                 fields = [ifields[ifieldname] for ifieldname in elem["Fields"]]
             except KeyError as key:
                 raise MicroprobeArchitectureDefinitionError(
-                    "Unknown field %s "
-                    "definition in "
-                    "instruction format"
-                    " '%s' found in '%s'." % (key, name, filename))
+                    f"Unknown field {key} definition in instruction format "
+                    f"'{name}' found in '{filename}'.")
 
             iformat = cls(name, descr, fields, assembly)
 
             if name in iformats:
-                raise MicroprobeArchitectureDefinitionError("Duplicated "
-                                                            "definition "
-                                                            "of instruction "
-                                                            "format "
-                                                            "'%s' found "
-                                                            "in '%s'" %
-                                                            (name, filename))
+                raise MicroprobeArchitectureDefinitionError(
+                    f"Duplicated definition of instruction format '{name}' "
+                    f"found in '{filename}'")
             LOG.debug(iformat)
             iformats[name] = iformat
 
@@ -115,11 +110,11 @@ def import_definition(cls, filenames, ifields):
 
 
 # Classes
-class InstructionFormat(six.with_metaclass(abc.ABCMeta, object)):
+class InstructionFormat(abc.ABC):
     """Abstract class to represent an instruction format"""
 
     @abc.abstractmethod
-    def __init__(self, fname, descr):
+    def __init__(self, fname: str, descr: str):
         """
 
         :param fname:
@@ -131,22 +126,20 @@ class InstructionFormat(six.with_metaclass(abc.ABCMeta, object)):
 
     @property
     def name(self):
-        """ """
         return self._name
 
     @property
     def description(self):
-        """ """
         return self._descr
 
-    @abc.abstractproperty
-    def fields(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def fields(self) -> List[InstructionField]:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def assembly_format(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def assembly_format(self) -> str:
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -160,7 +153,7 @@ class InstructionFormat(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_fields(self):
+    def get_fields(self) -> List[InstructionField]:
         """Returns a :class:`~.list` of
         the :class:`~.InstructionField`
 
@@ -169,7 +162,7 @@ class InstructionFormat(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_field(self, fname):
+    def get_field(self, fname: str) -> InstructionField:
         """Returns a the :class:`~.InstructionField` with name
         *fname*.
 
@@ -179,7 +172,7 @@ class InstructionFormat(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_field_props(self, fname):
+    def get_field_props(self, fname: str):
         """Returns extra properties of field with name *fname*.
 
         :param fname: Field name.
@@ -189,7 +182,7 @@ class InstructionFormat(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def get_findex(self, fname):
+    def get_findex(self, fname: str):
         """Returns the index of the field *fname* within the instruction format
 
         :param fname: Field name.
@@ -199,7 +192,7 @@ class InstructionFormat(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def flip_fields(self, fname1, fname2):
+    def flip_fields(self, fname1: str, fname2: str):
         """Interchanges the position of the fields with name *fname1* and
         *fname2*.
 
@@ -212,7 +205,7 @@ class InstructionFormat(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_fields(self, fields, reset=True):
+    def set_fields(self, fields: List[InstructionField], reset: bool = True):
         """Sets the fields of the instruction format. If *reset* is *True* the
         properties and the flip records of the fields are removed.
 
@@ -226,7 +219,6 @@ class InstructionFormat(six.with_metaclass(abc.ABCMeta, object)):
         raise NotImplementedError
 
     def __str__(self):
-        """ """
 
         values = "%-10s : %-30s ([" % (self.name, self.description)
 
@@ -254,7 +246,8 @@ class InstructionFormat(six.with_metaclass(abc.ABCMeta, object)):
 class GenericInstructionFormat(InstructionFormat):
     """Instruction format generic class."""
 
-    def __init__(self, fname, descr, fields, assembly):
+    def __init__(self, fname: str, descr: str, fields: List[InstructionField],
+                 assembly: str):
         """
 
         :param fname:
@@ -265,9 +258,10 @@ class GenericInstructionFormat(InstructionFormat):
         """
         super(GenericInstructionFormat, self).__init__(fname, descr)
         self._fname = fname
-        self._fields = []
-        self._props = []
-        self._flips = []
+        self._fields: List[InstructionField] = []
+        self._props: List[None] = [
+        ]  # TODO: Check if this list of None is needed
+        self._flips: List[Tuple[int, int]] = []
         self._length = 0
         self._assembly_format = assembly
 
@@ -278,17 +272,14 @@ class GenericInstructionFormat(InstructionFormat):
 
     @property
     def fields(self):
-        """ """
         return self._fields
 
     @property
     def length(self):
-        """ """
         return self._length
 
     @property
     def assembly_format(self):
-        """ """
         return self._assembly_format
 
     def get_operands(self):
@@ -309,7 +300,7 @@ class GenericInstructionFormat(InstructionFormat):
         """
         return self._fields
 
-    def get_field(self, fname):
+    def get_field(self, fname: str):
         """Returns a the :class:`~.InstructionField` with name
         *fname*.
 
@@ -321,15 +312,17 @@ class GenericInstructionFormat(InstructionFormat):
         ]
 
         if len(field) == 0:
-            raise MicroprobeLookupError("Unable to find a field "
-                                        "with name '%s'" % fname)
+            raise MicroprobeLookupError(
+                f"Unable to find a field with name '{fname}'")
 
-        assert len(field) == 1, "Field names should be key identifiers. " \
-                                "Field '%s' is duplicated" % fname
+        assert len(
+            field
+        ) == 1, "Field names should be key identifiers." + \
+            f" Field '{fname}' is duplicated"
 
         return field[0]
 
-    def get_field_props(self, fname):
+    def get_field_props(self, fname: str):
         """Returns extra properties of field with name *fname*.
 
         :param fname: Field name.
@@ -339,7 +332,7 @@ class GenericInstructionFormat(InstructionFormat):
         idx = self.get_findex(fname)
         return self._props[idx]
 
-    def get_findex(self, fname):
+    def get_findex(self, fname: str):
         """Returns the index of the field *fname* within the instruction
         format.
 
@@ -349,7 +342,7 @@ class GenericInstructionFormat(InstructionFormat):
         """
         return self.get_fields().index(self.get_field(fname))
 
-    def flip_fields(self, fname1, fname2):
+    def flip_fields(self, fname1: str, fname2: str):
         """Interchanges the position of the fields with name *fname1* and
         *fname2*.
 
@@ -375,7 +368,7 @@ class GenericInstructionFormat(InstructionFormat):
 
         self._flips.append((idx1, idx2))
 
-    def set_fields(self, fields, reset=True):
+    def set_fields(self, fields: List[InstructionField], reset: bool = True):
         """Sets the fields of the instruction format. If *reset* is *True* the
         properties and the flip records of the fields are removed.
 
@@ -394,7 +387,7 @@ class GenericInstructionFormat(InstructionFormat):
 
         self._compute_length()
 
-    def _add_field(self, field):
+    def _add_field(self, field: InstructionField):
         """Adds an field to the instruction format.
 
         :param field: Instruction field
@@ -405,7 +398,6 @@ class GenericInstructionFormat(InstructionFormat):
         self._props.append(None)
 
     def _compute_length(self):
-        """ """
 
         length = sum([field.size for field in self._fields])
         if length % 8 != 0:

--- a/src/microprobe/target/isa/instruction_format.py
+++ b/src/microprobe/target/isa/instruction_format.py
@@ -31,12 +31,9 @@ from microprobe.exceptions import MicroprobeArchitectureDefinitionError, \
 from microprobe.utils.logger import get_logger
 from microprobe.utils.yaml import read_yaml
 
-
 # Constants
-SCHEMA = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "schemas",
-    "instruction_format.yaml"
-)
+SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
+                      "instruction_format.yaml")
 LOG = get_logger(__name__)
 __all__ = [
     "import_definition", "InstructionFormat", "GenericInstructionFormat"
@@ -78,8 +75,7 @@ def import_definition(cls, filenames, ifields):
                 LOG.warning(
                     "Similar definition of instruction format: '%s' "
                     "and '%s'. Check if definition needed.", name,
-                    iformats_duplicated[key]
-                )
+                    iformats_duplicated[key])
             else:
                 iformats_duplicated[key] = name
 
@@ -90,8 +86,7 @@ def import_definition(cls, filenames, ifields):
                     "instruction format"
                     " '%s' found in '%s'"
                     " contains duplicated"
-                    " fields." % (name, filename)
-                )
+                    " fields." % (name, filename))
 
             try:
                 fields = [ifields[ifieldname] for ifieldname in elem["Fields"]]
@@ -100,20 +95,18 @@ def import_definition(cls, filenames, ifields):
                     "Unknown field %s "
                     "definition in "
                     "instruction format"
-                    " '%s' found in '%s'." % (key, name, filename)
-                )
+                    " '%s' found in '%s'." % (key, name, filename))
 
             iformat = cls(name, descr, fields, assembly)
 
             if name in iformats:
-                raise MicroprobeArchitectureDefinitionError(
-                    "Duplicated "
-                    "definition "
-                    "of instruction "
-                    "format "
-                    "'%s' found "
-                    "in '%s'" % (name, filename)
-                )
+                raise MicroprobeArchitectureDefinitionError("Duplicated "
+                                                            "definition "
+                                                            "of instruction "
+                                                            "format "
+                                                            "'%s' found "
+                                                            "in '%s'" %
+                                                            (name, filename))
             LOG.debug(iformat)
             iformats[name] = iformat
 
@@ -305,10 +298,8 @@ class GenericInstructionFormat(InstructionFormat):
         third is a :class:`~.bool` indicating if the operand is an output
         operand.
         """
-        return [
-            (field.get_foperand(), field.is_input(), field.is_output())
-            for field in self.get_fields() if field.get_fshow()
-        ]
+        return [(field.get_foperand(), field.is_input(), field.is_output())
+                for field in self.get_fields() if field.get_fshow()]
 
     def get_fields(self):
         """Returns a :class:`~.list` of the
@@ -330,10 +321,8 @@ class GenericInstructionFormat(InstructionFormat):
         ]
 
         if len(field) == 0:
-            raise MicroprobeLookupError(
-                "Unable to find a field "
-                "with name '%s'" % fname
-            )
+            raise MicroprobeLookupError("Unable to find a field "
+                                        "with name '%s'" % fname)
 
         assert len(field) == 1, "Field names should be key identifiers. " \
                                 "Field '%s' is duplicated" % fname
@@ -429,7 +418,6 @@ class GenericInstructionFormat(InstructionFormat):
 
             raise MicroprobeArchitectureDefinitionError(
                 "Instruction format"
-                " '%s' length is not multiple of a byte" % self.name
-            )
+                " '%s' length is not multiple of a byte" % self.name)
 
         self._length = sum([field.size for field in self._fields]) // 8

--- a/src/microprobe/target/isa/operand.py
+++ b/src/microprobe/target/isa/operand.py
@@ -38,11 +38,9 @@ from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import OrderedDict, natural_sort
 from microprobe.utils.yaml import read_yaml
 
-
 # Constants
-SCHEMA = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "schemas", "operand.yaml"
-)
+SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
+                      "operand.yaml")
 
 LOG = get_logger(__name__)
 __all__ = [
@@ -91,8 +89,7 @@ def import_definition(filenames, inherits, registers):
                         if len(regnames) == 1 and \
                                 regnames[0] in register_types:
                             regs = [
-                                reg
-                                for reg in registers.values()
+                                reg for reg in registers.values()
                                 if reg.type.name == regnames[0]
                             ]
                         else:
@@ -109,18 +106,11 @@ def import_definition(filenames, inherits, registers):
                             regs[registers[regname]] = []
                             for regname2 in regnames[regname]:
                                 regs[registers[regname]].append(
-                                    registers[regname2]
-                                )
+                                    registers[regname2])
 
                         key.append(
-                            tuple(
-                                [
-                                    (
-                                        k, tuple(v)
-                                    ) for k, v in regnames.items()
-                                ]
-                            )
-                        )
+                            tuple([(k, tuple(v))
+                                   for k, v in regnames.items()]))
 
                     address_base = elem.get("AddressBase", False)
                     address_index = elem.get("AddressIndex", False)
@@ -140,8 +130,9 @@ def import_definition(filenames, inherits, registers):
                     # They are not architected registers.
 
                     if isinstance(regs, list):
-                        regs = [reg for reg in regs
-                                if reg.representation != 'N/A']
+                        regs = [
+                            reg for reg in regs if reg.representation != 'N/A'
+                        ]
                     elif isinstance(regs, dict):
                         for elem in regs:
                             regs[elem] = [
@@ -149,10 +140,8 @@ def import_definition(filenames, inherits, registers):
                                 if reg2.representation != 'N/A'
                             ]
 
-                    operand = OperandReg(
-                        name, descr, regs, address_base, address_index,
-                        floating_point, vector
-                    )
+                    operand = OperandReg(name, descr, regs, address_base,
+                                         address_index, floating_point, vector)
 
                 elif "Min" in elem and "Max" in elem:
 
@@ -172,10 +161,9 @@ def import_definition(filenames, inherits, registers):
                     key.append(shift)
                     key.append(add)
 
-                    operand = OperandImmRange(
-                        name, descr, minval, maxval, step, address_index,
-                        shift, novalues, add
-                    )
+                    operand = OperandImmRange(name, descr, minval, maxval,
+                                              step, address_index, shift,
+                                              novalues, add)
 
                 elif "Values" in elem:
 
@@ -205,10 +193,9 @@ def import_definition(filenames, inherits, registers):
                     key.append(floating_point)
                     key.append(vector)
 
-                    operand = OperandConstReg(
-                        name, descr, reg, address_base, address_index,
-                        floating_point, vector
-                    )
+                    operand = OperandConstReg(name, descr, reg, address_base,
+                                              address_index, floating_point,
+                                              vector)
 
                 elif "Relative" in elem:
 
@@ -226,22 +213,20 @@ def import_definition(filenames, inherits, registers):
                     key.append(tuple([tuple(elem) for elem in except_ranges]))
 
                     operand = InstructionAddressRelativeOperand(
-                        name, descr, maxdispl, mindispl,
-                        shift, except_ranges, relative, step)
+                        name, descr, maxdispl, mindispl, shift, except_ranges,
+                        relative, step)
 
                 else:
                     raise MicroprobeArchitectureDefinitionError(
                         "Operand definition '%s' in '%s' not supported" %
-                        (name, filename)
-                    )
+                        (name, filename))
 
                 tkey = tuple(key)
                 if tkey in operands_duplicated:
                     LOG.warning(
                         "Similar definition of operands: '%s' and"
                         " '%s'. Check if definition needed.", name,
-                        operands_duplicated[tkey]
-                    )
+                        operands_duplicated[tkey])
                 else:
                     operands_duplicated[tkey] = name
 
@@ -253,16 +238,12 @@ def import_definition(filenames, inherits, registers):
                     "uses an unknown "
                     "register in '%s'"
                     "\nMissing defini"
-                    "tion of: %s" % (
-                        name, filename, exception
-                    )
-                )
+                    "tion of: %s" % (name, filename, exception))
 
             if name in operands and not override and filename not in inherits:
                 raise MicroprobeArchitectureDefinitionError(
                     "Duplicated definition of operand '%s' found in '%s'" %
-                    (name, filename)
-                )
+                    (name, filename))
 
             if name in operands:
                 LOG.debug("Redefined operand: %s", operand)
@@ -283,8 +264,8 @@ def _format_integer(operand, value):
     elif MICROPROBE_RC['hex_none']:
         return str(value)
     elif MICROPROBE_RC['hex_address']:
-        if (operand.address_relative or
-                operand.address_immediate or operand.address_absolute):
+        if (operand.address_relative or operand.address_immediate
+                or operand.address_absolute):
             if hex(value).endswith("L"):
                 return hex(value)[:-1]
             return hex(value)
@@ -344,10 +325,8 @@ class OperandDescriptor(object):
 
     def __repr__(self):
         """ """
-        return "%s(%s, %s, %s)" % (
-            self.__class__.__name__, self._type, self._is_input,
-            self._is_output
-        )
+        return "%s(%s, %s, %s)" % (self.__class__.__name__, self._type,
+                                   self._is_input, self._is_output)
 
 
 class MemoryOperandDescriptor(object):
@@ -472,11 +451,8 @@ class MemoryOperand(object):
 
     def _check_cmp(self, other):
         if not isinstance(other, self.__class__):
-            raise NotImplementedError(
-                "%s != %s" % (
-                    other.__class__, self.__class__
-                )
-            )
+            raise NotImplementedError("%s != %s" %
+                                      (other.__class__, self.__class__))
 
     def __eq__(self, other):
         """x.__eq__(y) <==> x==y"""
@@ -536,9 +512,8 @@ class MemoryOperand(object):
 
     def __str__(self):
         """ """
-        return "%s(Address: %s, Length: %s)" % (
-            self.__class__.__name__, self._address, self._length
-        )
+        return "%s(Address: %s, Length: %s)" % (self.__class__.__name__,
+                                                self._address, self._length)
 
     def full_report(self, tabs=0):
         shift = ("\t" * (tabs + 1))
@@ -552,17 +527,9 @@ class Operand(six.with_metaclass(abc.ABCMeta, object)):
     """This represents a machine instruction operand"""
 
     _cmp_attributes = [
-        "_name",
-        "_descr",
-        "_ai",
-        "_ab",
-        "_aim",
-        "_imm",
-        "_const",
-        "_rel",
-        "_rela",
-        "_fp",
-        "_vector"]
+        "_name", "_descr", "_ai", "_ab", "_aim", "_imm", "_const", "_rel",
+        "_rela", "_fp", "_vector"
+    ]
 
     @abc.abstractmethod
     def __init__(self, name, descr):
@@ -714,30 +681,23 @@ class Operand(six.with_metaclass(abc.ABCMeta, object)):
             the value is not allowed for the operand
         """
         if not self.__contains__(value):
-            raise MicroprobeValueError(
-                "Invalid operand value %s not in %s" % (value,
-                                                        list(self.values()))
-            )
+            raise MicroprobeValueError("Invalid operand value %s not in %s" %
+                                       (value, list(self.values())))
 
     def __str__(self):
         """ """
-        return "%-8s : %s (%s)" % (
-            self.name, self.description, self.__class__.__name__
-        )
+        return "%-8s : %s (%s)" % (self.name, self.description,
+                                   self.__class__.__name__)
 
     def __repr__(self):
         """ """
-        return "%s(\"%s\", \"%s\")" % (
-            self.__class__.__name__, self.name, self.description
-        )
+        return "%s(\"%s\", \"%s\")" % (self.__class__.__name__, self.name,
+                                       self.description)
 
     def _check_cmp(self, other):
         if not isinstance(other, self.__class__):
-            raise NotImplementedError(
-                "%s != %s" % (
-                    other.__class__, self.__class__
-                )
-            )
+            raise NotImplementedError("%s != %s" %
+                                      (other.__class__, self.__class__))
 
     def __eq__(self, other):
         """x.__eq__(y) <==> x==y"""
@@ -804,10 +764,8 @@ class OperandReg(Operand):
 
     """
 
-    def __init__(
-        self, name, descr, regs, address_base, address_index, floating_point,
-        vector
-    ):
+    def __init__(self, name, descr, regs, address_base, address_index,
+                 floating_point, vector):
         """
 
         :param name:
@@ -834,12 +792,12 @@ class OperandReg(Operand):
         self._vector = vector
 
         if self._fp is None:
-            self._fp = list(set([reg.type for reg in self._regs]))[
-                0].used_for_float_arithmetic
+            self._fp = list(set([reg.type for reg in self._regs
+                                 ]))[0].used_for_float_arithmetic
 
         if self._vector is None:
-            self._vector = list(set([reg.type for reg in self._regs]))[
-                0].used_for_vector_arithmetic
+            self._vector = list(set([reg.type for reg in self._regs
+                                     ]))[0].used_for_vector_arithmetic
 
     def values(self):
         """Return the possible value of the operand.
@@ -894,10 +852,8 @@ class OperandReg(Operand):
     def copy(self):
         """ """
 
-        return OperandReg(
-            self.name, self.description, self._regs.copy(), self._ab, self._ai,
-            self._fp, self._vector
-        )
+        return OperandReg(self.name, self.description, self._regs.copy(),
+                          self._ab, self._ai, self._fp, self._vector)
 
     def set_valid_values(self, values):
         """
@@ -925,9 +881,8 @@ class OperandImmRange(Operand):
 
     """
 
-    def __init__(
-        self, name, descr, minvalue, maxvalue, step, aim, shift, novalues, add
-    ):
+    def __init__(self, name, descr, minvalue, maxvalue, step, aim, shift,
+                 novalues, add):
         """
 
         :param name:
@@ -954,10 +909,9 @@ class OperandImmRange(Operand):
 
     def copy(self):
         """ """
-        return OperandImmRange(
-            self.name, self.description, self._min, self._max, self._step,
-            self._aim, self._shift, self._novalues, self._add
-        )
+        return OperandImmRange(self.name, self.description, self._min,
+                               self._max, self._step, self._aim, self._shift,
+                               self._novalues, self._add)
 
     def values(self):
         """Return the possible value of the operand.
@@ -966,10 +920,8 @@ class OperandImmRange(Operand):
         """
         if self._computed_values is None:
             self._computed_values = [
-                elem
-                for elem in range(
-                    self._min, self._max + 1, self._step
-                ) if elem not in self._novalues
+                elem for elem in range(self._min, self._max + 1, self._step)
+                if elem not in self._novalues
             ]
         return self._computed_values
 
@@ -983,8 +935,7 @@ class OperandImmRange(Operand):
             raise MicroprobeCodeGenerationError(
                 "Setting an operand without any valid value. Please check "
                 "the definition files. Previous value: '%s'. New values: '%s'"
-                "." % (list(self.values()), values)
-            )
+                "." % (list(self.values()), values))
 
         for value in values:
             assert value in list(self.values())
@@ -998,17 +949,10 @@ class OperandImmRange(Operand):
         :rtype: ::class:`~.int`
         """
         if self._computed_values is not None:
-            return self._computed_values[
-                random.randrange(
-                    0, len(
-                        self._computed_values
-                    )
-                )
-            ]
+            return self._computed_values[random.randrange(
+                0, len(self._computed_values))]
 
-        value = random.randrange(
-            self._min, self._max + 1, self._step
-        )
+        value = random.randrange(self._min, self._max + 1, self._step)
 
         if value not in self._novalues:
             return value
@@ -1071,10 +1015,9 @@ class OperandImmRange(Operand):
         """
 
         if not isinstance(value, six.integer_types):
-            raise MicroprobeValueError(
-                "Invalid operand value: '%s'. Integer"
-                " required and '%s' provided" % (value, type(value))
-            )
+            raise MicroprobeValueError("Invalid operand value: '%s'. Integer"
+                                       " required and '%s' provided" %
+                                       (value, type(value)))
 
         # value = value >> self._shift
         if value <= self._max and value >= self._min \
@@ -1085,12 +1028,9 @@ class OperandImmRange(Operand):
 
         else:
 
-            raise MicroprobeValueError(
-                "Invalid operand value: %d (max: %d,"
-                " min: %d)" % (
-                    value, self._max, self._min
-                )
-            )
+            raise MicroprobeValueError("Invalid operand value: %d (max: %d,"
+                                       " min: %d)" %
+                                       (value, self._max, self._min))
 
     def access(self, dummy):
         """
@@ -1130,19 +1070,14 @@ class OperandValueSet(Operand):
         if rep is not None and len(rep) != len(values):
             raise MicroprobeArchitectureDefinitionError(
                 "Values and representation of operand definition "
-                "'%s' do not have the same length." % name
-            )
+                "'%s' do not have the same length." % name)
         if rep is not None:
             self._rep = dict(zip(values, rep))
 
     def copy(self):
         """ """
-        return OperandValueSet(
-            self.name,
-            self.description,
-            self._values,
-            self._rep
-        )
+        return OperandValueSet(self.name, self.description, self._values,
+                               self._rep)
 
     def values(self):
         """Return the possible value of the operand.
@@ -1314,10 +1249,8 @@ class OperandConstReg(Operand):
 
     """
 
-    def __init__(
-        self, name, descr, reg, address_base, address_index, floating_point,
-        vector
-    ):
+    def __init__(self, name, descr, reg, address_base, address_index,
+                 floating_point, vector):
         """
 
         :param name:
@@ -1340,19 +1273,17 @@ class OperandConstReg(Operand):
         self._vector = vector
 
         if self._fp is None:
-            self._fp = list(set([reg.type for reg in self._regs]))[
-                0].used_for_float_arithmetic
+            self._fp = list(set([reg.type for reg in self._regs
+                                 ]))[0].used_for_float_arithmetic
 
         if self._vector is None:
-            self._vector = list(set([reg.type for reg in self._regs]))[
-                0].used_for_float_arithmetic
+            self._vector = list(set([reg.type for reg in self._regs
+                                     ]))[0].used_for_float_arithmetic
 
     def copy(self):
         """ """
-        return OperandConstReg(
-            self.name, self.description, self._reg, self._ab, self._ai,
-            self._fp, self._vector
-        )
+        return OperandConstReg(self.name, self.description, self._reg,
+                               self._ab, self._ai, self._fp, self._vector)
 
     def values(self):
         """Return the possible value of the operand.
@@ -1424,16 +1355,8 @@ class InstructionAddressRelativeOperand(Operand):
     and the target. Examples are : branch relative, or load address relative.
     """
 
-    def __init__(
-            self,
-            name,
-            descr,
-            maxdispl,
-            mindispl,
-            shift,
-            except_range,
-            relative,
-            step):
+    def __init__(self, name, descr, maxdispl, mindispl, shift, except_range,
+                 relative, step):
         """Create a InstructionAddressRelativeOperand object.
 
         :param name: Operand name
@@ -1464,10 +1387,11 @@ class InstructionAddressRelativeOperand(Operand):
 
     def copy(self):
         """ """
-        return InstructionAddressRelativeOperand(
-            self.name, self.description, self._maxdispl, self._mindispl,
-            self._shift, self._except, self._rel, self._step
-        )
+        return InstructionAddressRelativeOperand(self.name, self.description,
+                                                 self._maxdispl,
+                                                 self._mindispl, self._shift,
+                                                 self._except, self._rel,
+                                                 self._step)
 
     def values(self):
         """Return the possible value of the operand.
@@ -1515,8 +1439,7 @@ class InstructionAddressRelativeOperand(Operand):
             else:
                 raise MicroprobeCodeGenerationError(
                     "Unable to generate the string representation of '%s'"
-                    " with value: '%s'" % (self, value)
-                )
+                    " with value: '%s'" % (self, value))
 
             if displacement > 0:
                 str_value = "%s+0x%x" % (str_value, displacement)
@@ -1552,10 +1475,8 @@ class InstructionAddressRelativeOperand(Operand):
         else:
             if not isinstance(value[0], Address) or \
                     not isinstance(value[1], Address):
-                raise MicroprobeValueError(
-                    "Invalid operand value '%s'."
-                    " Any Address?" % (value)
-                )
+                raise MicroprobeValueError("Invalid operand value '%s'."
+                                           " Any Address?" % (value))
             cvalue = value[0] - value[1]
 
         if cvalue > (self._maxdispl << self._shift) or \
@@ -1566,10 +1487,8 @@ class InstructionAddressRelativeOperand(Operand):
                 "Invalid operand value '%d' "
                 "not within the"
                 " allowed range (%d, %d) and exceptions"
-                " '%s' " % (
-                    cvalue, self._mindispl, self._maxdispl, self._except
-                )
-            )
+                " '%s' " %
+                (cvalue, self._mindispl, self._maxdispl, self._except))
 
     def codification(self, value):
         """
@@ -1581,13 +1500,11 @@ class InstructionAddressRelativeOperand(Operand):
         if isinstance(value, six.integer_types):
             return str(value >> self._shift)
         elif isinstance(value, Address):
-            raise MicroprobeCodeGenerationError(
-                "Unable to codify the"
-                " symbolic address: %s ."
-                " Consider to add a pass to"
-                " translate them to actual "
-                "values " % value
-            )
+            raise MicroprobeCodeGenerationError("Unable to codify the"
+                                                " symbolic address: %s ."
+                                                " Consider to add a pass to"
+                                                " translate them to actual "
+                                                "values " % value)
         else:
             raise NotImplementedError
 

--- a/src/microprobe/target/isa/operand.py
+++ b/src/microprobe/target/isa/operand.py
@@ -276,7 +276,7 @@ def _format_integer(operand, value):
 
 
 # Classes
-class OperandDescriptor(object):
+class OperandDescriptor:
     """Class to represent an operand descriptor.
 
     """
@@ -324,12 +324,11 @@ class OperandDescriptor(object):
         return OperandDescriptor(self.type, self.is_input, self.is_output)
 
     def __repr__(self):
-        """ """
         return "%s(%s, %s, %s)" % (self.__class__.__name__, self._type,
                                    self._is_input, self._is_output)
 
 
-class MemoryOperandDescriptor(object):
+class MemoryOperandDescriptor:
     """Class to represent a memory operand descriptor.
 
     """
@@ -420,7 +419,7 @@ class MemoryOperandDescriptor(object):
         return rstr
 
 
-class MemoryOperand(object):
+class MemoryOperand:
     """This represents a machine instruction memory operand. It contains
     the operands, the formula, the
 
@@ -446,7 +445,6 @@ class MemoryOperand(object):
 
     @property
     def length_operands(self):
-        """ """
         return self._length
 
     def _check_cmp(self, other):
@@ -511,7 +509,6 @@ class MemoryOperand(object):
         return True
 
     def __str__(self):
-        """ """
         return "%s(Address: %s, Length: %s)" % (self.__class__.__name__,
                                                 self._address, self._length)
 
@@ -523,7 +520,7 @@ class MemoryOperand(object):
         return rstr
 
 
-class Operand(six.with_metaclass(abc.ABCMeta, object)):
+class Operand(abc.ABC):
     """This represents a machine instruction operand"""
 
     _cmp_attributes = [
@@ -685,12 +682,10 @@ class Operand(six.with_metaclass(abc.ABCMeta, object)):
                                        (value, list(self.values())))
 
     def __str__(self):
-        """ """
         return "%-8s : %s (%s)" % (self.name, self.description,
                                    self.__class__.__name__)
 
     def __repr__(self):
-        """ """
         return "%s(\"%s\", \"%s\")" % (self.__class__.__name__, self.name,
                                        self.description)
 
@@ -850,7 +845,6 @@ class OperandReg(Operand):
         return value.name in [reg.name for reg in self.values()]
 
     def copy(self):
-        """ """
 
         return OperandReg(self.name, self.description, self._regs.copy(),
                           self._ab, self._ai, self._fp, self._vector)
@@ -908,7 +902,6 @@ class OperandImmRange(Operand):
         self._computed_values = None
 
     def copy(self):
-        """ """
         return OperandImmRange(self.name, self.description, self._min,
                                self._max, self._step, self._aim, self._shift,
                                self._novalues, self._add)
@@ -984,27 +977,22 @@ class OperandImmRange(Operand):
 
     @property
     def max(self):
-        """ """
         return self._max
 
     @property
     def min(self):
-        """ """
         return self._min
 
     @property
     def step(self):
-        """ """
         return self._step
 
     @property
     def shift(self):
-        """ """
         return self._shift
 
     @property
     def add(self):
-        """ """
         return self._add
 
     def check(self, value):
@@ -1075,7 +1063,6 @@ class OperandValueSet(Operand):
             self._rep = dict(zip(values, rep))
 
     def copy(self):
-        """ """
         return OperandValueSet(self.name, self.description, self._values,
                                self._rep)
 
@@ -1121,12 +1108,10 @@ class OperandValueSet(Operand):
 
     @property
     def shift(self):
-        """ """
         return 0
 
     @property
     def min(self):
-        """ """
         return min(self._values)
 
     def __contains__(self, value):
@@ -1172,7 +1157,6 @@ class OperandConst(Operand):
         self._const = True
 
     def copy(self):
-        """ """
         return OperandConst(self.name, self.description, self._value)
 
     def values(self):
@@ -1207,12 +1191,10 @@ class OperandConst(Operand):
 
     @property
     def shift(self):
-        """ """
         return 0
 
     @property
     def min(self):
-        """ """
         return self._value
 
     def access(self, dummy):
@@ -1281,7 +1263,6 @@ class OperandConstReg(Operand):
                                      ]))[0].used_for_float_arithmetic
 
     def copy(self):
-        """ """
         return OperandConstReg(self.name, self.description, self._reg,
                                self._ab, self._ai, self._fp, self._vector)
 
@@ -1386,7 +1367,6 @@ class InstructionAddressRelativeOperand(Operand):
         self._step = step
 
     def copy(self):
-        """ """
         return InstructionAddressRelativeOperand(self.name, self.description,
                                                  self._maxdispl,
                                                  self._mindispl, self._shift,
@@ -1510,7 +1490,6 @@ class InstructionAddressRelativeOperand(Operand):
 
     @property
     def shift(self):
-        """ """
         return self._shift
 
     def access(self, dummy):

--- a/src/microprobe/target/isa/register.py
+++ b/src/microprobe/target/isa/register.py
@@ -16,15 +16,15 @@
 """
 
 # Futures
-from __future__ import absolute_import
+from __future__ import absolute_import, annotations
 
 # Built-in modules
 import abc
 import hashlib
 import os
+from typing import List, TYPE_CHECKING
 
 # Third party modules
-import six
 from six.moves import range
 
 # Own modules
@@ -32,6 +32,10 @@ from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import Pickable
 from microprobe.utils.yaml import read_yaml
+
+# Type hinting
+if TYPE_CHECKING:
+    from microprobe.target.isa.register_type import RegisterType
 
 # Constants
 SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
@@ -42,7 +46,7 @@ __all__ = ["import_definition", "Register", "GenericRegister"]
 
 
 # Functions
-def import_definition(cls, filenames, regtypes):
+def import_definition(cls, filenames: List[str], regtypes):
     """
 
     :param filenames:
@@ -103,52 +107,53 @@ def import_definition(cls, filenames, regtypes):
 
 
 # Classes
-class Register(six.with_metaclass(abc.ABCMeta, object)):
+class Register(abc.ABC):
     """Abstract class to represent an architecture register."""
 
     @abc.abstractmethod
     def __init__(self):
-        """ """
         pass
 
-    @abc.abstractproperty
-    def type(self):
+    @property
+    @abc.abstractmethod
+    def type(self) -> RegisterType:
         """Register type (:class:`~.RegisterType` instance)."""
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def name(self):
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
         """Register name (:class:`~.str` instance)."""
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def description(self):
+    @property
+    @abc.abstractmethod
+    def description(self) -> str:
         """Register description (:class:`~.str` instance)."""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def representation(self):
+    def representation(self) -> str:
         """Return the assembly representation of this register."""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def codification(self):
+    def codification(self) -> str:
         """Return the assembly representation of this register."""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def __str__(self):
+    def __str__(self) -> str:
         """Return the string representation of this register."""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def __repr__(self):
+    def __repr__(self) -> str:
         """Return the string representation of this register."""
         raise NotImplementedError
 
     @abc.abstractmethod
-    def __hash__(self):
-        """ """
+    def __hash__(self) -> int:
         raise NotImplementedError
 
 
@@ -157,7 +162,8 @@ class GenericRegister(Register, Pickable):
 
     _cmp_attributes = ["type", "representation", "name"]
 
-    def __init__(self, name, descr, rtype, rrepr, rcodi):
+    def __init__(self, name: str, descr: str, rtype: RegisterType, rrepr,
+                 rcodi):
         """
 
         :param name:
@@ -179,31 +185,25 @@ class GenericRegister(Register, Pickable):
 
     @property
     def type(self):
-        """ """
         return self._rtype
 
     @property
     def name(self):
-        """ """
         return self._name
 
     @property
     def description(self):
-        """ """
         return self._descr
 
     @property
     def representation(self):
-        """ """
         return str(self._rrepr)
 
     @property
     def codification(self):
-        """ """
         return str(self._rcodi)
 
     def __hash__(self):
-        """ """
         return self._hash
 
     def _check_cmp(self, other):
@@ -322,12 +322,10 @@ class GenericRegister(Register, Pickable):
         return True
 
     def __str__(self):
-        """ """
         return "%8s : %s (Type: %s)" % (self._name, self._descr,
                                         self._rtype.name)
 
     def __repr__(self):
-        """ """
         return "%s('%s')" % (self.__class__.__name__, self.name)
 
     def __getattr__(self, name):

--- a/src/microprobe/target/isa/register.py
+++ b/src/microprobe/target/isa/register.py
@@ -33,11 +33,9 @@ from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import Pickable
 from microprobe.utils.yaml import read_yaml
 
-
 # Constants
-SCHEMA = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "schemas", "register.yaml"
-)
+SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
+                      "register.yaml")
 
 LOG = get_logger(__name__)
 __all__ = ["import_definition", "Register", "GenericRegister"]
@@ -75,8 +73,7 @@ def import_definition(cls, filenames, regtypes):
             if rtype not in regtypes:
                 raise MicroprobeArchitectureDefinitionError(
                     "Unknown register type in definition of "
-                    "register '%s' in file '%s'" % (name, filename)
-                )
+                    "register '%s' in file '%s'" % (name, filename))
 
             if repeat:
                 rfrom = repeat["From"]
@@ -96,8 +93,7 @@ def import_definition(cls, filenames, regtypes):
                 if cname in regs:
                     raise MicroprobeArchitectureDefinitionError(
                         "Duplicated register definition of '%s' found"
-                        " in '%s'" % (cname, filename)
-                    )
+                        " in '%s'" % (cname, filename))
 
                 LOG.debug(regt)
                 regs[cname] = regt
@@ -176,11 +172,10 @@ class GenericRegister(Register, Pickable):
         self._descr = descr
         self._rrepr = rrepr
         self._rcodi = rcodi
-        self._hash = int(hashlib.sha512(
-            (
-                self.name + self.description +
-                self.representation + str(hash(self.type))
-            ).encode()).hexdigest(), 16)
+        self._hash = int(
+            hashlib.sha512(
+                (self.name + self.description + self.representation +
+                 str(hash(self.type))).encode()).hexdigest(), 16)
 
     @property
     def type(self):
@@ -213,11 +208,8 @@ class GenericRegister(Register, Pickable):
 
     def _check_cmp(self, other):
         if not isinstance(other, self.__class__):
-            raise NotImplementedError(
-                "%s != %s" % (
-                    other.__class__, self.__class__
-                )
-            )
+            raise NotImplementedError("%s != %s" %
+                                      (other.__class__, self.__class__))
 
     def __eq__(self, other):
         """x.__eq__(y) <==> x==y"""
@@ -331,9 +323,8 @@ class GenericRegister(Register, Pickable):
 
     def __str__(self):
         """ """
-        return "%8s : %s (Type: %s)" % (
-            self._name, self._descr, self._rtype.name
-        )
+        return "%8s : %s (Type: %s)" % (self._name, self._descr,
+                                        self._rtype.name)
 
     def __repr__(self):
         """ """
@@ -348,7 +339,5 @@ class GenericRegister(Register, Pickable):
         try:
             return self._rtype.__getattribute__(name)
         except AttributeError:
-            raise AttributeError(
-                "'%s' object has no attribute '%s'" %
-                (self.__class__.__name__, name)
-            )
+            raise AttributeError("'%s' object has no attribute '%s'" %
+                                 (self.__class__.__name__, name))

--- a/src/microprobe/target/isa/register_type.py
+++ b/src/microprobe/target/isa/register_type.py
@@ -31,11 +31,9 @@ from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.logger import get_logger
 from microprobe.utils.yaml import read_yaml
 
-
 # Constants
-SCHEMA = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "schemas", "register_type.yaml"
-)
+SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
+                      "register_type.yaml")
 LOG = get_logger(__name__)
 __all__ = ["import_definition", "RegisterType", "GenericRegisterType"]
 
@@ -72,8 +70,7 @@ def import_definition(cls, filenames, dummy):
                 LOG.warning(
                     "Similar definition of register types: '%s' and"
                     " '%s'. Check if definition needed.", name,
-                    regts_duplicated[key]
-                )
+                    regts_duplicated[key])
             else:
                 regts_duplicated[key] = name
 
@@ -83,8 +80,7 @@ def import_definition(cls, filenames, dummy):
                 raise MicroprobeArchitectureDefinitionError(
                     "Duplicated "
                     "definition of register type '%s' "
-                    "found in '%s'" % (name, filename)
-                )
+                    "found in '%s'" % (name, filename))
 
             regts[name] = regt
 
@@ -133,15 +129,13 @@ class RegisterType(six.with_metaclass(abc.ABCMeta, object)):
 
     def __str__(self):
         """x.__str__() <==> str(x)"""
-        return "%8s: %s (bit size: %d)" % (
-            self.name, self.description, self.size
-        )
+        return "%8s: %s (bit size: %d)" % (self.name, self.description,
+                                           self.size)
 
     def __repr__(self):
         """x.__repr__() <==> str(x)"""
-        return "%8s: %s (bit size: %d)" % (
-            self.name, self.description, self.size
-        )
+        return "%8s: %s (bit size: %d)" % (self.name, self.description,
+                                           self.size)
 
     @abc.abstractmethod
     def __hash__(self):
@@ -165,12 +159,9 @@ class GenericRegisterType(RegisterType):
     """
 
     _cmp_attributes = [
-        "name",
-        "description",
-        "size",
-        "used_for_address_arithmetic",
-        "used_for_float_arithmetic",
-        "used_for_vector_arithmetic"]
+        "name", "description", "size", "used_for_address_arithmetic",
+        "used_for_float_arithmetic", "used_for_vector_arithmetic"
+    ]
 
     def __init__(self, rtype, rdescr, rsize, u4aa, u4fa, u4va):
         """
@@ -190,12 +181,13 @@ class GenericRegisterType(RegisterType):
         self._used_for_address_arithmetic = u4aa
         self._used_for_float_arithmetic = u4fa
         self._used_for_vector_arithmetic = u4va
-        self._hash = int(hashlib.sha512((
-                str(self.name) + str(self.description) + str(self.size) +
-                str(self.used_for_address_arithmetic) +
-                str(self.used_for_float_arithmetic) +
-                str(self.used_for_vector_arithmetic)).encode()).hexdigest(),
-                16)
+        self._hash = int(
+            hashlib.sha512(
+                (str(self.name) + str(self.description) + str(self.size) +
+                 str(self.used_for_address_arithmetic) +
+                 str(self.used_for_float_arithmetic) +
+                 str(self.used_for_vector_arithmetic)).encode()).hexdigest(),
+            16)
 
     @property
     def name(self):
@@ -233,11 +225,8 @@ class GenericRegisterType(RegisterType):
 
     def _check_cmp(self, other):
         if not isinstance(other, self.__class__):
-            raise NotImplementedError(
-                "%s != %s" % (
-                    other.__class__, self.__class__
-                )
-            )
+            raise NotImplementedError("%s != %s" %
+                                      (other.__class__, self.__class__))
 
     def __eq__(self, other):
         """x.__eq__(y) <==> x==y"""

--- a/src/microprobe/target/isa/register_type.py
+++ b/src/microprobe/target/isa/register_type.py
@@ -22,9 +22,9 @@ from __future__ import absolute_import
 import abc
 import hashlib
 import os
+from typing import Dict, List, Tuple
 
 # Third party modules
-import six
 
 # Own modules
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError
@@ -40,7 +40,7 @@ __all__ = ["import_definition", "RegisterType", "GenericRegisterType"]
 # Functions
 
 
-def import_definition(cls, filenames, dummy):
+def import_definition(cls, filenames: List[str], dummy):
     """
 
     :param filenames:
@@ -50,7 +50,7 @@ def import_definition(cls, filenames, dummy):
 
     LOG.debug("Start")
     regts = {}
-    regts_duplicated = {}
+    regts_duplicated: Dict[Tuple[int, bool, bool, bool], str] = {}
 
     for filename in filenames:
         regt_data = read_yaml(filename, SCHEMA)
@@ -89,42 +89,44 @@ def import_definition(cls, filenames, dummy):
 
 
 # Classes
-class RegisterType(six.with_metaclass(abc.ABCMeta, object)):
+class RegisterType(abc.ABC):
     """Abstract base class to represent a Register Type"""
 
     @abc.abstractmethod
     def __init__(self):
-        """ """
         pass
 
-    @abc.abstractproperty
-    def name(self):
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
         """Register type name (:class:`~.str`)"""
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def description(self):
+    @property
+    @abc.abstractmethod
+    def description(self) -> str:
         """Register type name (:class:`~.str`)"""
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def size(self):
+    @property
+    @abc.abstractmethod
+    def size(self) -> int:
         """Register size in bits (::class:`~.int`)"""
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def used_for_address_arithmetic(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def used_for_address_arithmetic(self) -> bool:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def used_for_float_arithmetic(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def used_for_float_arithmetic(self) -> bool:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def used_for_vector_arithmetic(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def used_for_vector_arithmetic(self) -> bool:
         raise NotImplementedError
 
     def __str__(self):
@@ -138,8 +140,7 @@ class RegisterType(six.with_metaclass(abc.ABCMeta, object)):
                                            self.size)
 
     @abc.abstractmethod
-    def __hash__(self):
-        """ """
+    def __hash__(self) -> int:
         raise NotImplementedError
 
 
@@ -163,7 +164,8 @@ class GenericRegisterType(RegisterType):
         "used_for_float_arithmetic", "used_for_vector_arithmetic"
     ]
 
-    def __init__(self, rtype, rdescr, rsize, u4aa, u4fa, u4va):
+    def __init__(self, rtype: str, rdescr: str, rsize: int, u4aa: bool,
+                 u4fa: bool, u4va: bool):
         """
 
         :param rtype:
@@ -206,21 +208,17 @@ class GenericRegisterType(RegisterType):
 
     @property
     def used_for_address_arithmetic(self):
-        """ """
         return self._used_for_address_arithmetic
 
     @property
     def used_for_float_arithmetic(self):
-        """ """
         return self._used_for_float_arithmetic
 
     @property
     def used_for_vector_arithmetic(self):
-        """ """
         return self._used_for_vector_arithmetic
 
     def __hash__(self):
-        """ """
         return self._hash
 
     def _check_cmp(self, other):

--- a/src/microprobe/target/isa/schemas/__init__.py
+++ b/src/microprobe/target/isa/schemas/__init__.py
@@ -16,7 +16,6 @@
 <your module documentation here>.
 """
 
-
 # Constants
 __all__ = []
 

--- a/src/microprobe/target/uarch/__init__.py
+++ b/src/microprobe/target/uarch/__init__.py
@@ -16,11 +16,12 @@
 """
 
 # Futures
-from __future__ import absolute_import
+from __future__ import absolute_import, annotations
 
 # Built-in modules
 import abc
 import os
+from typing import TYPE_CHECKING, List
 
 # Third party modules
 
@@ -31,14 +32,17 @@ from microprobe import MICROPROBE_RC
 from microprobe.exceptions import MicroprobeYamlFormatError
 from microprobe.property import PropertyHolder, import_properties
 from microprobe.target.uarch.cache import cache_hierarchy_from_elements
-from microprobe.utils.imp import get_object_from_module, \
-    import_cls_definition, import_definition, import_operand_definition
+from microprobe.utils.imp import get_object_from_module, import_definition
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import findfiles
 from microprobe.utils.yaml import read_yaml
 import six
 
 # Local modules
+
+# Type hinting
+if TYPE_CHECKING:
+    from microprobe.target import Target, Definition
 
 # Constants
 SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
@@ -54,7 +58,7 @@ __all__ = [
 
 
 # Functions
-def _read_uarch_extensions(uarchdefs, path):
+def _read_uarch_extensions(uarchdefs, path: str):
     """ """
 
     if "Extends" in uarchdefs[-1]:
@@ -72,7 +76,7 @@ def _read_uarch_extensions(uarchdefs, path):
         _read_uarch_extensions(uarchdefs, uarchdefval)
 
 
-def _read_yaml_definition(uarchdefs, path):
+def _read_yaml_definition(uarchdefs, path: str):
     """
 
     :param uarchdefs:
@@ -141,7 +145,7 @@ def _read_yaml_definition(uarchdefs, path):
     return complete_uarchdef
 
 
-def import_microarchitecture_definition(path):
+def import_microarchitecture_definition(path: str):
     """Imports a Microarchitecture definition given a path
 
     :param path:
@@ -182,7 +186,7 @@ def import_microarchitecture_definition(path):
     return uarch
 
 
-def find_microarchitecture_definitions(paths=None):
+def find_microarchitecture_definitions(paths: List[str] | None = None):
 
     if paths is None:
         paths = []
@@ -190,7 +194,7 @@ def find_microarchitecture_definitions(paths=None):
     paths = paths + MICROPROBE_RC["microarchitecture_paths"] \
         + MICROPROBE_RC["default_paths"]
 
-    results = []
+    results: List[Definition] = []
     uarchfiles = findfiles(paths, "^microarchitecture.yaml$")
 
     if len(uarchfiles) > 0:
@@ -226,22 +230,21 @@ class Microarchitecture(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
 
     @abc.abstractmethod
     def __init__(self):
-        """ """
         pass
 
-    @abc.abstractproperty
-    def name(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def description(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def description(self) -> str:
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def elements(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -255,16 +258,14 @@ class Microarchitecture(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
 
     @abc.abstractmethod
     def full_report(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
-    def __str__(self):
-        """ """
+    def __str__(self) -> str:
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_target(self, target):
+    def set_target(self, target: Target):
         """
 
         :param target:
@@ -272,16 +273,17 @@ class Microarchitecture(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
         """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def target(self):
-        """ """
         raise NotImplementedError
 
 
 class GenericMicroarchitecture(Microarchitecture):
     """ """
 
-    def __init__(self, name, descr, elements, instruction_properties_defs):
+    def __init__(self, name: str, descr: str, elements,
+                 instruction_properties_defs):
         """
 
         :param name:
@@ -299,25 +301,21 @@ class GenericMicroarchitecture(Microarchitecture):
 
     @property
     def name(self):
-        """ """
         return self._name
 
     @property
     def description(self):
-        """ """
         return self._descr
 
     @property
     def elements(self):
-        """ """
         return self._elements
 
     @property
     def target(self):
-        """ """
         return self._target
 
-    def set_target(self, target):
+    def set_target(self, target: Target):
         """
 
         :param target:
@@ -335,7 +333,6 @@ class GenericMicroarchitecture(Microarchitecture):
             import_properties(cfile, instructions)
 
     def full_report(self):
-        """ """
         rstr = "-" * 80 + "\n"
         rstr += "Microarchitecture Name: %s\n" % self.name
         rstr += "Microarchitecture Description: %s\n" % self.name
@@ -352,7 +349,6 @@ class GenericMicroarchitecture(Microarchitecture):
         return rstr
 
     def __str__(self):
-        """ """
         return "%s('%s', '%s')" % (self.__class__.__name__, self.name,
                                    self.description)
 
@@ -365,7 +361,8 @@ class GenericCPUMicroarchitecture(GenericMicroarchitecture):
 
     """
 
-    def __init__(self, name, descr, elements, instruction_properties_defs):
+    def __init__(self, name: str, descr: str, elements,
+                 instruction_properties_defs):
         """
 
         :param name:
@@ -382,5 +379,4 @@ class GenericCPUMicroarchitecture(GenericMicroarchitecture):
 
     @property
     def cache_hierarchy(self):
-        """ """
         return self._cache_hierarchy

--- a/src/microprobe/target/uarch/__init__.py
+++ b/src/microprobe/target/uarch/__init__.py
@@ -40,16 +40,11 @@ import six
 
 # Local modules
 
-
 # Constants
-SCHEMA = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "schemas",
-    "microarchitecture.yaml"
-)
-DEFAULT_UARCH = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "default",
-    "microarchitecture.yaml"
-)
+SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
+                      "microarchitecture.yaml")
+DEFAULT_UARCH = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                             "default", "microarchitecture.yaml")
 LOG = get_logger(__name__)
 __all__ = [
     "import_microarchitecture_definition",
@@ -70,10 +65,7 @@ def _read_uarch_extensions(uarchdefs, path):
             uarchdefval = os.path.join(path, uarchdefval)
 
         uarchdef = read_yaml(
-            os.path.join(
-                uarchdefval, "microarchitecture.yaml"
-            ), SCHEMA
-        )
+            os.path.join(uarchdefval, "microarchitecture.yaml"), SCHEMA)
         uarchdef["Path"] = uarchdefval
         uarchdefs.append(uarchdef)
 
@@ -127,29 +119,22 @@ def _read_yaml_definition(uarchdefs, path):
                         else:
                             if override:
                                 complete_uarchdef[key][key2] = [
-                                    os.path.join(
-                                        uarchdef["Path"], val[key2]
-                                    )
+                                    os.path.join(uarchdef["Path"], val[key2])
                                 ]
                             else:
                                 complete_uarchdef[key][key2].append(
-                                    os.path.join(
-                                        uarchdef["Path"], val[key2]
-                                    )
-                                )
+                                    os.path.join(uarchdef["Path"], val[key2]))
                     elif key2 == "Module":
                         if val[key2].startswith("microprobe"):
-                            val[key2] = os.path.join(
-                                os.path.dirname(__file__), "..", "..", "..",
-                                val[key2]
-                            )
+                            val[key2] = os.path.join(os.path.dirname(__file__),
+                                                     "..", "..", "..",
+                                                     val[key2])
 
                         if os.path.isabs(val[key2]):
                             complete_uarchdef[key][key2] = val[key2]
                         else:
                             complete_uarchdef[key][key2] = os.path.join(
-                                uarchdef["Path"], val[key2]
-                            )
+                                uarchdef["Path"], val[key2])
                     else:
                         complete_uarchdef[key][key2] = val[key2]
 
@@ -172,38 +157,26 @@ def import_microarchitecture_definition(path):
     uarchdef = _read_yaml_definition([], path)
 
     element_types, force = import_definition(
-        uarchdef, os.path.join(
-            path, "microarchitecture.yaml"
-        ), "Element_type", getattr(microprobe.target.uarch, 'element_type'),
-        None
-    )
+        uarchdef, os.path.join(path, "microarchitecture.yaml"), "Element_type",
+        getattr(microprobe.target.uarch, 'element_type'), None)
 
-    element, force = import_definition(
-        uarchdef,
-        os.path.join(
-            path, "microarchitecture.yaml"
-        ),
-        "Element",
-        getattr(
-            microprobe.target.uarch, 'element'
-        ),
-        element_types,
-        force=force
-    )
+    element, force = import_definition(uarchdef,
+                                       os.path.join(path,
+                                                    "microarchitecture.yaml"),
+                                       "Element",
+                                       getattr(microprobe.target.uarch,
+                                               'element'),
+                                       element_types,
+                                       force=force)
 
-    uarch_cls = get_object_from_module(
-        uarchdef["Microarchitecture"]["Class"],
-        uarchdef["Microarchitecture"]["Module"]
-    )
+    uarch_cls = get_object_from_module(uarchdef["Microarchitecture"]["Class"],
+                                       uarchdef["Microarchitecture"]["Module"])
 
-    uarch = uarch_cls(
-        uarchdef["Name"], uarchdef["Description"], element,
-        uarchdef["Instruction_properties"]["Path"]
-    )
+    uarch = uarch_cls(uarchdef["Name"], uarchdef["Description"], element,
+                      uarchdef["Instruction_properties"]["Path"])
 
-    import_properties(
-        os.path.join(path, "microarchitecture.yaml"), {uarchdef["Name"]: uarch}
-    )
+    import_properties(os.path.join(path, "microarchitecture.yaml"),
+                      {uarchdef["Name"]: uarch})
 
     LOG.info("Microarchitecture '%s' imported", uarch)
     return uarch
@@ -233,13 +206,10 @@ def find_microarchitecture_definitions(paths=None):
             continue
 
         try:
-            definition = Definition(
-                uarchfile, isadef["Name"], isadef["Description"]
-            )
-            if (
-                definition not in results and
-                not definition.name.endswith("common")
-            ):
+            definition = Definition(uarchfile, isadef["Name"],
+                                    isadef["Description"])
+            if (definition not in results
+                    and not definition.name.endswith("common")):
                 results.append(definition)
 
         except TypeError as exc:
@@ -371,13 +341,8 @@ class GenericMicroarchitecture(Microarchitecture):
         rstr += "Microarchitecture Description: %s\n" % self.name
         rstr += "-" * 80 + "\n"
         rstr += "Element Types:\n"
-        for elem in sorted(
-            set(
-                [
-                    elem.type for elem in self.elements.values()
-                ]
-            )
-        ):
+        for elem in sorted(set([elem.type
+                                for elem in self.elements.values()])):
             rstr += str(elem) + "\n"
         rstr += "-" * 80 + "\n"
         rstr += "Elements:\n"
@@ -388,9 +353,8 @@ class GenericMicroarchitecture(Microarchitecture):
 
     def __str__(self):
         """ """
-        return "%s('%s', '%s')" % (
-            self.__class__.__name__, self.name, self.description
-        )
+        return "%s('%s', '%s')" % (self.__class__.__name__, self.name,
+                                   self.description)
 
 
 class GenericCPUMicroarchitecture(GenericMicroarchitecture):
@@ -410,11 +374,9 @@ class GenericCPUMicroarchitecture(GenericMicroarchitecture):
         :param instruction_properties_defs:
 
         """
-        super(
-            GenericCPUMicroarchitecture, self
-        ).__init__(
-            name, descr, elements, instruction_properties_defs
-        )
+        super(GenericCPUMicroarchitecture,
+              self).__init__(name, descr, elements,
+                             instruction_properties_defs)
 
         self._cache_hierarchy = cache_hierarchy_from_elements(elements)
 

--- a/src/microprobe/target/uarch/cache.py
+++ b/src/microprobe/target/uarch/cache.py
@@ -16,10 +16,11 @@
 """
 
 # Futures
-from __future__ import absolute_import, division, print_function
+from __future__ import absolute_import, division, print_function, annotations
 
 # Built-in modules
 import math
+from typing import TYPE_CHECKING, Dict, List
 
 # Third party modules
 from six.moves import range
@@ -27,6 +28,10 @@ from six.moves import range
 # Own modules
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.logger import get_logger
+
+# Type checking
+if TYPE_CHECKING:
+    from microprobe.target.uarch.element import MicroarchitectureElement
 
 # Constants
 LOG = get_logger(__name__)
@@ -66,7 +71,7 @@ def _caches_from_elements(elements):
 
     LOG.debug("Start")
 
-    caches = []
+    caches: List[Cache] = []
     for element in elements.values():
 
         LOG.debug("Checking: '%s'", element)
@@ -119,11 +124,12 @@ def _caches_from_elements(elements):
 
 
 # Classes
-class Cache(object):
+class Cache:
     """Class to represent a cache."""
 
-    def __init__(self, element, size, level, line_size, address_size, data,
-                 ins):
+    def __init__(self, element: MicroarchitectureElement, size: int,
+                 level: int, line_size: int, address_size: int, data: bool,
+                 ins: bool):
         """Create a Cache object.
 
         :param element: Micrarchitecture element
@@ -187,7 +193,7 @@ class Cache(object):
     @property
     def name(self):
         """Cache name (class:`~.str`)."""
-        return "%s Cache" % self.element.full_name
+        return f"{self.element.full_name} Cache"
 
     @property
     def description(self):
@@ -211,8 +217,9 @@ class Cache(object):
 class SetAssociativeCache(Cache):
     """Class to represent a set-associative cache."""
 
-    def __init__(self, element, size, level, line_size, address_size, data,
-                 ins, ways):
+    def __init__(self, element: MicroarchitectureElement, size: int,
+                 level: int, line_size: int, address_size: int, data: bool,
+                 ins: bool, ways: int):
         """Create a SetAssociativeCache object.
 
         :param element: Micrarchitecture element
@@ -300,7 +307,7 @@ class SetAssociativeCache(Cache):
         """
         return list(range(0, self._setsways))
 
-    def congruence_class(self, value):
+    def congruence_class(self, value: int):
         """Return the congruence class for a given *value*.
 
         :param value: Address
@@ -311,7 +318,7 @@ class SetAssociativeCache(Cache):
         cgc = (value >> self.offset_bits) & ((1 << (self._set_bits)) - 1)
         return cgc
 
-    def offset(self, value):
+    def offset(self, value: int):
         """
 
         :param value:
@@ -321,7 +328,6 @@ class SetAssociativeCache(Cache):
         return cgc
 
     def print_info(self):
-        """ """
 
         from microprobe.utils.cmdline import print_info
         print_info(self._offset_bits)
@@ -340,10 +346,10 @@ class SetAssociativeCache(Cache):
         print_info((bit_range, offset_range, ccrange))
 
 
-class CacheHierarchy(object):
+class CacheHierarchy:
     """Class to represent a cache hierarchy."""
 
-    def __init__(self, caches):
+    def __init__(self, caches: List[Cache]):
         """
 
         :param caches:
@@ -371,11 +377,11 @@ class CacheHierarchy(object):
                 "At least one cache"
                 "should be defined as first level data cache")
 
-        data_levels = {}
+        data_levels: Dict[MicroarchitectureElement, List[Cache]] = {}
         for cache in first_data_levels:
             data_levels[cache.element] = [cache]
 
-        ins_levels = {}
+        ins_levels: Dict[MicroarchitectureElement, List[Cache]] = {}
         for cache in first_ins_levels:
             ins_levels[cache.element] = [cache]
 
@@ -439,7 +445,8 @@ class CacheHierarchy(object):
         self._data_levels = data_levels
         self._ins_levels = ins_levels
 
-    def get_data_hierarchy_from_element(self, element):
+    def get_data_hierarchy_from_element(self,
+                                        element: MicroarchitectureElement):
         """
 
         :param element:
@@ -457,7 +464,8 @@ class CacheHierarchy(object):
 
         return rhierarchy[0]
 
-    def get_instruction_hierarchy_from_element(self, element):
+    def get_instruction_hierarchy_from_element(
+            self, element: MicroarchitectureElement):
         """
 
         :param element:
@@ -476,6 +484,5 @@ class CacheHierarchy(object):
         return rhierarchy[0]
 
     def data_linesize(self):
-        """ """
         return self._data_levels[list(
             self._data_levels.keys())[0]][0].line_size

--- a/src/microprobe/target/uarch/cache.py
+++ b/src/microprobe/target/uarch/cache.py
@@ -28,7 +28,6 @@ from six.moves import range
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.logger import get_logger
 
-
 # Constants
 LOG = get_logger(__name__)
 __all__ = [
@@ -51,8 +50,7 @@ def cache_hierarchy_from_elements(elements):
         raise MicroprobeArchitectureDefinitionError(
             "Expecting cache hierarchy"
             " elements in the microarchitecture"
-            " description, but none found."
-        )
+            " description, but none found.")
 
     cache_hierarchy = CacheHierarchy(caches)
 
@@ -81,8 +79,7 @@ def _caches_from_elements(elements):
                 "Microarchitecture "
                 "definition requires the definition of the "
                 "'data_cache' and 'instruction_cache' properties "
-                "for the element types."
-            )
+                "for the element types.")
 
         LOG.debug("Cache element found:'%s'", element)
 
@@ -96,8 +93,7 @@ def _caches_from_elements(elements):
             raise MicroprobeArchitectureDefinitionError(
                 "Element '%s' defined as a cache, but required "
                 "property '%s' not specified in its type "
-                "'%s'" % (element, exc.message.split("'")[3], element.type)
-            )
+                "'%s'" % (element, exc.message.split("'")[3], element.type))
 
         # Figuring out the cache type based on element attributes
         # Right now, we only implement N-way set associative
@@ -105,18 +101,18 @@ def _caches_from_elements(elements):
         ways = getattr(element.type, "cache_ways", None)
 
         if ways is not None:
-            new_cache = SetAssociativeCache(
-                element, size, level, line_size, address_size,
-                element.type.data_cache, element.type.instruction_cache, ways
-            )
+            new_cache = SetAssociativeCache(element, size, level, line_size,
+                                            address_size,
+                                            element.type.data_cache,
+                                            element.type.instruction_cache,
+                                            ways)
             caches.append(new_cache)
         else:
             raise MicroprobeArchitectureDefinitionError(
                 "Element '%s' defined "
                 "as a cache, but cache type can not be "
                 "determined. Please specify on of the "
-                "following properties: ['cache_ways']"
-            )
+                "following properties: ['cache_ways']")
 
     LOG.debug("End")
     return caches
@@ -126,9 +122,8 @@ def _caches_from_elements(elements):
 class Cache(object):
     """Class to represent a cache."""
 
-    def __init__(
-        self, element, size, level, line_size, address_size, data, ins
-    ):
+    def __init__(self, element, size, level, line_size, address_size, data,
+                 ins):
         """Create a Cache object.
 
         :param element: Micrarchitecture element
@@ -216,9 +211,8 @@ class Cache(object):
 class SetAssociativeCache(Cache):
     """Class to represent a set-associative cache."""
 
-    def __init__(
-        self, element, size, level, line_size, address_size, data, ins, ways
-    ):
+    def __init__(self, element, size, level, line_size, address_size, data,
+                 ins, ways):
         """Create a SetAssociativeCache object.
 
         :param element: Micrarchitecture element
@@ -240,9 +234,9 @@ class SetAssociativeCache(Cache):
         :return: Cache instance
         :rtype: :class:`~.Cache`
         """
-        super(SetAssociativeCache, self).__init__(
-            element, size, level, line_size, address_size, data, ins
-        )
+        super(SetAssociativeCache,
+              self).__init__(element, size, level, line_size, address_size,
+                             data, ins)
 
         self._ways = ways
         self._address_size = address_size
@@ -362,8 +356,7 @@ class CacheHierarchy(object):
         ]
 
         first_ins_levels = [
-            cache
-            for cache in caches
+            cache for cache in caches
             if cache.level == 1 and cache.contains_instructions
         ]
 
@@ -371,14 +364,12 @@ class CacheHierarchy(object):
             raise MicroprobeArchitectureDefinitionError(
                 "At least one cache"
                 "should be defined as first level instruction"
-                "cache."
-            )
+                "cache.")
 
         if len(first_data_levels) == 0:
             raise MicroprobeArchitectureDefinitionError(
                 "At least one cache"
-                "should be defined as first level data cache"
-            )
+                "should be defined as first level data cache")
 
         data_levels = {}
         for cache in first_data_levels:
@@ -390,13 +381,11 @@ class CacheHierarchy(object):
 
         current_level = 2
         next_data_levels = [
-            cache
-            for cache in caches
+            cache for cache in caches
             if cache.level == current_level and cache.contains_data
         ]
         next_ins_levels = [
-            cache
-            for cache in caches
+            cache for cache in caches
             if cache.level == current_level and cache.contains_instructions
         ]
 
@@ -410,11 +399,9 @@ class CacheHierarchy(object):
 
                     assert data_level.level == (current_level - 1)
 
-                    new_level = sorted(
-                        next_data_levels,
-                        key=lambda x, elem=element:
-                        x.element.closest_common_element(elem).depth
-                    )[-1]
+                    new_level = sorted(next_data_levels,
+                                       key=lambda x, elem=element: x.element.
+                                       closest_common_element(elem).depth)[-1]
 
                     data_levels[element].append(new_level)
 
@@ -433,8 +420,7 @@ class CacheHierarchy(object):
                         :type elem:
                         """
                         return elem.element.closest_common_element(
-                            element
-                        ).depth
+                            element).depth
 
                     new_level = sorted(next_ins_levels, key=my_key)[-1]
 
@@ -442,13 +428,11 @@ class CacheHierarchy(object):
 
             current_level += 1
             next_data_levels = [
-                cache
-                for cache in caches
+                cache for cache in caches
                 if cache.level == current_level and cache.contains_data
             ]
             next_ins_levels = [
-                cache
-                for cache in caches
+                cache for cache in caches
                 if cache.level == current_level and cache.contains_instructions
             ]
 
@@ -464,8 +448,7 @@ class CacheHierarchy(object):
 
         LOG.debug("Generating hierarchy from '%s'", element)
         rhierarchy = [
-            entry_level
-            for entry_level in self._data_levels.values()
+            entry_level for entry_level in self._data_levels.values()
             if element in [cache.element for cache in entry_level]
         ]
 
@@ -483,8 +466,7 @@ class CacheHierarchy(object):
 
         LOG.debug("Generating hierarchy from '%s'", element)
         rhierarchy = [
-            entry_level
-            for entry_level in self._ins_levels.values()
+            entry_level for entry_level in self._ins_levels.values()
             if element in [cache.element for cache in entry_level]
         ]
 
@@ -495,5 +477,5 @@ class CacheHierarchy(object):
 
     def data_linesize(self):
         """ """
-        return self._data_levels[
-            list(self._data_levels.keys())[0]][0].line_size
+        return self._data_levels[list(
+            self._data_levels.keys())[0]][0].line_size

--- a/src/microprobe/target/uarch/element.py
+++ b/src/microprobe/target/uarch/element.py
@@ -202,37 +202,36 @@ class MicroarchitectureElement(six.with_metaclass(abc.ABCMeta,
 
     @abc.abstractmethod
     def __init__(self):
-        """ """
         pass
 
-    @abc.abstractproperty
-    def name(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def name(self) -> str:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def full_name(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def full_name(self) -> str:
         raise NotImplementedError
 
-    @abc.abstractproperty
-    def description(self):
-        """ """
+    @property
+    @abc.abstractmethod
+    def description(self) -> str:
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def type(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def depth(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def subelements(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -244,14 +243,14 @@ class MicroarchitectureElement(six.with_metaclass(abc.ABCMeta,
         """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def parent(self):
-        """ """
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def parents(self):
-        """ """
         raise NotImplementedError
 
     @abc.abstractmethod
@@ -305,46 +304,38 @@ class GenericMicroarchitectureElement(MicroarchitectureElement):
 
     @property
     def name(self):
-        """ """
         return self._name
 
     @property
     def full_name(self):
-        """ """
         if self._parent is None:
             return self._name
         return "%s_%s" % (self._name, self.parent.full_name)
 
     @property
     def parents(self):
-        """ """
         if self._parent is None:
             return []
         return [self.parent] + self.parent.parents
 
     @property
     def description(self):
-        """ """
         return self._descr
 
     @property
     def type(self):
-        """ """
         return self._type
 
     @property
     def subelements(self):
-        """ """
         return list(self._subelements.values())
 
     @property
     def parent(self):
-        """ """
         return self._parent
 
     @property
     def depth(self):
-        """ """
         if self._parent is None:
             return 0
         return 1 + self.parent.depth
@@ -387,7 +378,6 @@ class GenericMicroarchitectureElement(MicroarchitectureElement):
         return None
 
     def __hash__(self):
-        """ """
         return self._hash
 
     def __str__(self):

--- a/src/microprobe/target/uarch/element.py
+++ b/src/microprobe/target/uarch/element.py
@@ -34,11 +34,9 @@ from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import RejectingDict
 from microprobe.utils.yaml import read_yaml
 
-
 # Constants
-SCHEMA = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "schemas", "element.yaml"
-)
+SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
+                      "element.yaml")
 
 LOG = get_logger(__name__)
 __all__ = [
@@ -77,8 +75,7 @@ def import_definition(cls, filenames, element_types):
                     "Unknown "
                     "microarchitecture element type in "
                     "microarchitecture element definition "
-                    " '%s' found in '%s'" % (name, filename)
-                )
+                    " '%s' found in '%s'" % (name, filename))
             descr = elem.get("Description", elem_type.description)
 
             if repeat:
@@ -97,8 +94,7 @@ def import_definition(cls, filenames, element_types):
                 except ValueError:
                     raise MicroprobeArchitectureDefinitionError(
                         "Duplicated microarchitecture element "
-                        "definition '%s' found in '%s'" % (name, filename)
-                    )
+                        "definition '%s' found in '%s'" % (name, filename))
 
             LOG.debug(element)
 
@@ -112,8 +108,7 @@ def import_definition(cls, filenames, element_types):
             raise MicroprobeArchitectureDefinitionError(
                 "Undefined sub-element '%s' in element "
                 "definition '%s'. Check following "
-                "files: %s" % (exc, elem, filenames)
-            )
+                "files: %s" % (exc, elem, filenames))
 
         elements[elem].set_subelements(subelements_instances)
 
@@ -139,9 +134,8 @@ def import_definition(cls, filenames, element_types):
                 for parent in sorted(parents):
                     LOG.debug("Duplicating for parent: %s", parent)
                     # Create a new copy
-                    new_element = cls(
-                        element.name, element.description, element.type
-                    )
+                    new_element = cls(element.name, element.description,
+                                      element.type)
                     new_element.set_subelements(element.subelements)
                     element_list.append(new_element)
 
@@ -168,10 +162,8 @@ def import_definition(cls, filenames, element_types):
             raise MicroprobeArchitectureDefinitionError(
                 "Wrong hierarchy of microarchitecture "
                 "elements. The definition of element"
-                " '%s' has multiple parents: '%s'." % (
-                    element, [str(elem) for elem in parents]
-                )
-            )
+                " '%s' has multiple parents: '%s'." %
+                (element, [str(elem) for elem in parents]))
         elif len(parents) == 0:
             if top_element is not None:
                 raise MicroprobeArchitectureDefinitionError(
@@ -179,8 +171,7 @@ def import_definition(cls, filenames, element_types):
                     "elements. There are at least two top "
                     "elements: '%s' and '%s'. Define a single "
                     "parent element for all the hierarchy." %
-                    (element, top_element)
-                )
+                    (element, top_element))
             top_element = element
         else:
             element.set_parent_element(parents[0])
@@ -190,16 +181,12 @@ def import_definition(cls, filenames, element_types):
             "Wrong hierarchy of microarchitecture "
             "elements. There is not a top element."
             " Define a single parent element for all "
-            "the hierarchy."
-        )
+            "the hierarchy.")
 
     LOG.info("Element hierarchy correct")
 
-    elem_dict = dict(
-        [
-            (element.full_name, element) for element in element_list
-        ]
-    )
+    elem_dict = dict([(element.full_name, element)
+                      for element in element_list])
 
     for filename in filenames:
         import_properties(filename, elem_dict)
@@ -209,10 +196,8 @@ def import_definition(cls, filenames, element_types):
 
 
 # Classes
-class MicroarchitectureElement(
-    six.with_metaclass(
-        abc.ABCMeta,
-        PropertyHolder)):
+class MicroarchitectureElement(six.with_metaclass(abc.ABCMeta,
+                                                  PropertyHolder)):
     """ """
 
     @abc.abstractmethod
@@ -313,11 +298,10 @@ class GenericMicroarchitectureElement(MicroarchitectureElement):
 
         self._parent = None
         self._subelements = {}
-        self._hash = int(hashlib.sha512(
-            (
-                self.name + self.description +
-                self.full_name + str(self.type) + str(self.depth)
-            ).encode()).hexdigest(), 16)
+        self._hash = int(
+            hashlib.sha512(
+                (self.name + self.description + self.full_name +
+                 str(self.type) + str(self.depth)).encode()).hexdigest(), 16)
 
     @property
     def name(self):
@@ -380,9 +364,8 @@ class GenericMicroarchitectureElement(MicroarchitectureElement):
         :param subelements:
 
         """
-        self._subelements = dict(
-            [(element.name, element) for element in subelements]
-        )
+        self._subelements = dict([(element.name, element)
+                                  for element in subelements])
 
         for subelement in subelements:
             subelement.set_parent_element(self)
@@ -409,18 +392,13 @@ class GenericMicroarchitectureElement(MicroarchitectureElement):
 
     def __str__(self):
         """Return the string representation of this element"""
-        return "%s('%s','%s','%s')" % (
-            self.__class__.__name__, self.name, self.full_name,
-            self.description
-        )
+        return "%s('%s','%s','%s')" % (self.__class__.__name__, self.name,
+                                       self.full_name, self.description)
 
     def _check_cmp(self, other):
         if not isinstance(other, self.__class__):
-            raise NotImplementedError(
-                "%s != %s" % (
-                    other.__class__, self.__class__
-                )
-            )
+            raise NotImplementedError("%s != %s" %
+                                      (other.__class__, self.__class__))
 
     def __eq__(self, other):
         """x.__eq__(y) <==> x==y"""

--- a/src/microprobe/target/uarch/element_type.py
+++ b/src/microprobe/target/uarch/element_type.py
@@ -30,11 +30,9 @@ from microprobe.property import PropertyHolder, import_properties
 from microprobe.utils.logger import get_logger
 from microprobe.utils.yaml import read_yaml
 
-
 # Constants
-SCHEMA = os.path.join(
-    os.path.dirname(os.path.abspath(__file__)), "schemas", "element_type.yaml"
-)
+SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
+                      "element_type.yaml")
 
 LOG = get_logger(__name__)
 __all__ = [
@@ -83,9 +81,7 @@ def import_definition(cls, filenames, dummy):
 
 # Classes
 class MicroarchitectureElementType(
-    six.with_metaclass(
-        abc.ABCMeta,
-        PropertyHolder)):
+        six.with_metaclass(abc.ABCMeta, PropertyHolder)):
     """Abstract class to represent a microarchitecture element type."""
 
     @abc.abstractmethod
@@ -115,9 +111,7 @@ class MicroarchitectureElementType(
 
 
 class GenericMicroarchitectureElementType(
-    six.with_metaclass(
-        abc.ABCMeta,
-        MicroarchitectureElementType)):
+        six.with_metaclass(abc.ABCMeta, MicroarchitectureElementType)):
     """Class to represent a generic microarchitecture element type."""
 
     def __init__(self, name, description):
@@ -147,9 +141,8 @@ class GenericMicroarchitectureElementType(
     def __str__(self):
         """Return the string representation of this element type
         (:class:`~.str`)."""
-        return "%s('%s','%s')" % (
-            self.__class__.__name__, self.name, self.description
-        )
+        return "%s('%s','%s')" % (self.__class__.__name__, self.name,
+                                  self.description)
 
     def __lt__(self, other):
 

--- a/src/microprobe/target/uarch/element_type.py
+++ b/src/microprobe/target/uarch/element_type.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 # Built-in modules
 import abc
 import os
+from typing import List
 
 # Third party modules
 import six
@@ -42,7 +43,7 @@ __all__ = [
 
 
 # Functions
-def import_definition(cls, filenames, dummy):
+def import_definition(cls, filenames: List[str], dummy):
     """
 
     :param cls:
@@ -93,12 +94,14 @@ class MicroarchitectureElementType(
         """
         pass
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def name(self):
         """Microarchitecture element type name (:class:`~.str`)."""
         raise NotImplementedError
 
-    @abc.abstractproperty
+    @property
+    @abc.abstractmethod
     def description(self):
         """Microarchitecture element type description (:class:`~.str`)."""
         raise NotImplementedError

--- a/src/microprobe/target/uarch/schemas/__init__.py
+++ b/src/microprobe/target/uarch/schemas/__init__.py
@@ -16,7 +16,6 @@
 <your module documentation here>.
 """
 
-
 # Constants
 __all__ = []
 


### PR DESCRIPTION
Commit 1: Run the [yapf command from utils/ensure_style.sh](https://github.com/IBM/microprobe/blob/master/dev_tools/utils/ensure_style.sh#L18) on the /code folder

Commit 2: Add basic type hints to files in the /code folder.
This includes common refactoring like class(abc.ABC):, removing empty docstrings, **kwargs, adding some TODOs, `@abc.abstractproperty` -> `@property  @abc.abstractmethod`, etc.

This is a best-effort start to add a baseline since there is so much code in this folder. As more of the project gets annotated, I'll go back through and use the other type hints to add more types to this folder.