### PR TITLE
Add mypy to CI flow

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,6 +78,12 @@ jobs:
               - . ./dev_tools/ci/travis_prolog
               - ./dev_tools/ci/code_conventions_003_documentation.sh
         - stage: tests
+          name: mypy
+          script:
+              - set -e
+              - . ./dev_tools/ci/travis_prolog
+              - ./dev_tools/ci/code_conventions_004_mypy.sh
+        - stage: tests
           name: tools RISCV
           script:
               - set -e

--- a/dev_tools/ci/check_ci.sh
+++ b/dev_tools/ci/check_ci.sh
@@ -23,6 +23,7 @@ shellcheck -x -s sh ./*.sh dev_tools/*/*.sh ./targets/*/dev_tools/*/*.sh
 ./dev_tools/ci/code_conventions_001_pycodestyle.sh
 ./dev_tools/ci/code_conventions_002_pylint.sh
 ./dev_tools/ci/code_conventions_003_documentation.sh
+./dev_tools/ci/code_conventions_004_mypy.sh
 # Fast Functional Tests (run for branches and PR)
 ./dev_tools/ci/test_001_end2end_tools.sh
 ./dev_tools/ci/test_002_end2end_examples.sh

--- a/dev_tools/ci/code_conventions_004_mypy.sh
+++ b/dev_tools/ci/code_conventions_004_mypy.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env sh
+# Copyright 2011-2021 IBM Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Microprobe CI support scripts
+#
+
+set -e # Finish right after a non-zero return command
+
+if [ "$WORKSPACE" = "" ]; then
+	WORKSPACE=$(pwd)
+    export WORKSPACE
+fi
+
+# shellcheck source=dev_tools/ci/environment.sh
+. "$WORKSPACE/dev_tools/ci/environment.sh"
+start_script "$0"
+
+echo "Running mypy version:"
+python "$(command -v mypy)" --version
+
+set +e
+# shellcheck disable=SC2046
+$NICE python "$(command -v mypy)" src/microprobe/code src/microprobe/target --ignore-missing-imports --install-types --non-interactive > "mypy$PYTHON_VERSION.out"
+error=$?
+set -e
+
+echo "Return code: $error"
+
+error=$(echo "obase=2;$error" | bc | /usr/bin/tail -c 3)
+if [ "$error" != "0" ]; then
+    echo "Errors found, check mypy$PYTHON_VERSION.out file and fix them"
+	exit_error "$0" "mypy$PYTHON_VERSION.out"
+fi
+
+# TODO: check other error codes to be more strict
+echo "No errors found!"
+exit_success "$0"
+
+# vim: set tabstop=4 softtabstop=4 shiftwidth=4 expandtab

--- a/requirements_devel.txt
+++ b/requirements_devel.txt
@@ -48,3 +48,4 @@ pep8-naming
 yapf
 isort<5,>=4.2.5
 # twine
+mypy

--- a/src/microprobe/code/bbl.py
+++ b/src/microprobe/code/bbl.py
@@ -82,8 +82,8 @@ class Bbl:
 
         self._instdic = {}
 
-        self._address = None
-        self._displacement = 0
+        self._address: Address | None = None
+        self._displacement: int | None = 0
 
         if MICROPROBE_RC["verbose"]:
             progress = Progress(size, "Initializing BBL:")
@@ -104,7 +104,12 @@ class Bbl:
                     self._instrs[self._pointer] = instructions[idx]
                 else:
                     self._instrs[self._pointer] = Instruction()
-                self._instdic[self._instrs[self._pointer]] = self._pointer
+
+                # Type hinting needs some help here :)
+                instr_index: Instruction | None = self._instrs[self._pointer]
+                assert instr_index is not None
+
+                self._instdic[instr_index] = self._pointer
                 self._pointer += 10
                 if MICROPROBE_RC["verbose"]:
                     progress()
@@ -153,7 +158,7 @@ class Bbl:
         """Size of the basic block, number of instructions (::class:`~.int`)"""
         return len(self.instrs)
 
-    def _index(self, instr: Instruction):
+    def _index(self, instr: Instruction | None):
         """Returns the index of the given instruction within the basic block.
 
         Returns the index of the given instruction within the basic block.
@@ -163,7 +168,10 @@ class Bbl:
         :type instr: :class:`~.Instruction`
 
         """
-        return self._instdic.get(instr, -1)
+        if instr is None:
+            return -1
+        else:
+            return self._instdic.get(instr, -1)
 
     def get_instruction_index(self, instr: Instruction):
         """Returns the index of the given instruction within the basic block.

--- a/src/microprobe/code/context.py
+++ b/src/microprobe/code/context.py
@@ -79,7 +79,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
         self._symbolic = symbolic
         self._fabsolute = absolute
 
-        self._dat = None
+        self._dat: DynamicAddressTranslation | None = None
 
         if default_context is not None:
             self = default_context.copy()
@@ -167,7 +167,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
         # assert value in self._value_registers.keys()
         # assert self._register_values[register] == value
 
-    def get_closest_value(self, value: int | float | Address | str):
+    def get_closest_value(self, value):
         """Returns the closest value to the given value.
 
         Returns the closest value to the given value. If there are
@@ -179,7 +179,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
 
         """
 
-        possible_regs: List[Tuple[Register, int | float | Address | str]] = []
+        possible_regs = []
 
         for reg, val in self._register_values.items():
 
@@ -224,7 +224,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
 
         return None
 
-    def get_register_closest_value(self, value: int | float | str):
+    def get_register_closest_value(self, value):
         """Returns the register with the closest value to the given value.
 
         Returns the register with the closest value to the given value.
@@ -237,7 +237,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
 
         """
 
-        possible_regs: List[Tuple[Register, int | float | str]] = []
+        possible_regs = []
 
         for reg, reg_value in self._register_values.items():
 
@@ -248,6 +248,8 @@ class Context(object):  # pylint: disable=too-many-public-methods
                 continue
 
             if isinstance(reg_value, str):
+                # Type hinting needs some help with this one :)
+                assert isinstance(value, str)
                 if reg_value.split("_")[1] != value.split(" ")[1]:
                     continue
 
@@ -310,7 +312,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
         for reg in registers:
             self.unset_register(reg)
 
-    def unset_register(self, register: Register):
+    def unset_register(self, register):
         """Remove the value from a register.
 
         :param register: Registers

--- a/src/microprobe/driver/__init__.py
+++ b/src/microprobe/driver/__init__.py
@@ -15,8 +15,10 @@
 
 """
 
+from typing import List
+
 # Constants
-__all__ = []
+__all__: List[str] = []
 
 # Functions
 

--- a/src/microprobe/driver/guided.py
+++ b/src/microprobe/driver/guided.py
@@ -15,8 +15,10 @@
 
 """
 
+from typing import List
+
 # Constants
-__all__ = []
+__all__: List[str] = []
 
 # Functions
 

--- a/src/microprobe/schemas/__init__.py
+++ b/src/microprobe/schemas/__init__.py
@@ -16,9 +16,10 @@
 <your module documentation here>.
 """
 
+from typing import List
 
 # Constants
-__all__ = []
+__all__: List[str] = []
 
 # Functions
 

--- a/src/microprobe/target/__init__.py
+++ b/src/microprobe/target/__init__.py
@@ -96,6 +96,9 @@ def import_definition(definition_tuple: str
     if isinstance(definition_tuple, str):
         definition_tuple = _parse_definition_tuple(definition_tuple)
 
+    # Type hinting needs some help here :)
+    assert not isinstance(definition_tuple, str)
+
     isa_def, uarch_def, env_def = definition_tuple
     isa = import_isa_definition(os.path.dirname(isa_def.filename))
     env = import_env_definition(env_def.filename,
@@ -349,10 +352,10 @@ class Target(Pickable):
         :return: Target instance
         :rtype: :class:`~.Target`
         """
-        self._uarch = None
-        self._env = None
+        self._uarch: Microarchitecture | None = None
+        self._env: Environment | None = None
         self._policies = None
-        self._wrapper = None
+        self._wrapper: Wrapper | None = None
 
         self.set_isa(isa)
 

--- a/src/microprobe/target/env/__init__.py
+++ b/src/microprobe/target/env/__init__.py
@@ -247,7 +247,7 @@ class Environment(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
         raise NotImplementedError
 
     @abc.abstractmethod
-    def set_target(self, target):
+    def set_target(self, target: Target):
         """
 
         :param target:
@@ -304,7 +304,7 @@ class GenericEnvironment(Environment):
         self._isa = isa
         self._reserved_registers: List[Register] = []
         self._threads = 1
-        self._target = None
+        self._target: Target | None = None
         self._default_wrapper = None
         self._little_endian = little_endian
         self.register_property(

--- a/src/microprobe/target/isa/__init__.py
+++ b/src/microprobe/target/isa/__init__.py
@@ -664,13 +664,14 @@ class GenericISA(ISA):
         self._path = path
         self._instructions = ins
         self._registers = regs
-        self._target = None
+        self._target: Target | None = None
 
         self._address_registers = [
-            reg for reg in regs.values() if reg.used_for_address_arithmetic
+            reg for reg in regs.values()
+            if reg.type.used_for_address_arithmetic
         ]
         self._float_registers = [
-            reg for reg in regs.values() if reg.used_for_float_arithmetic
+            reg for reg in regs.values() if reg.type.used_for_float_arithmetic
         ]
 
         self._comparators = []

--- a/src/microprobe/target/isa/instruction.py
+++ b/src/microprobe/target/isa/instruction.py
@@ -59,7 +59,7 @@ __all__ = [
 
 
 # Functions
-def import_definition(cls, filenames: List[str], args):
+def import_definition(cls, filenames, args):
     """
 
     :param filenames:

--- a/src/microprobe/target/isa/instruction_field.py
+++ b/src/microprobe/target/isa/instruction_field.py
@@ -21,7 +21,7 @@ from __future__ import absolute_import, annotations
 # Built-in modules
 import abc
 import os
-from typing import TYPE_CHECKING, Dict, List, Tuple
+from typing import TYPE_CHECKING, Dict, List, Tuple, cast
 
 # Third party modules
 
@@ -64,12 +64,12 @@ def import_definition(cls, filenames: List[str], operands: Dict[str, Operand]):
         for elem in ifield_data:
             name = elem["Name"]
             descr = elem.get("Description", "No description")
-            size = elem["Size"]
-            show = elem.get("Show", False)
-            fio = elem.get("IO", "?")
-            operand_def = elem.get("Operand", "Zero")
+            size = cast(int, elem["Size"])
+            show = cast(bool, elem.get("Show", False))
+            fio = cast(str, elem.get("IO", "?"))
+            operand_def = cast(str, elem.get("Operand", "Zero"))
 
-            key = tuple([size, show, fio, operand_def])
+            key = (size, show, fio, operand_def)
 
             if key in ifields_duplicated:
                 LOG.warning(

--- a/src/microprobe/target/isa/instruction_format.py
+++ b/src/microprobe/target/isa/instruction_format.py
@@ -45,7 +45,7 @@ __all__ = [
 
 
 # Functions
-def import_definition(cls, filenames: List[str], ifields):
+def import_definition(cls, filenames, ifields):
     """
 
     :param filenames:

--- a/src/microprobe/target/isa/register_type.py
+++ b/src/microprobe/target/isa/register_type.py
@@ -40,7 +40,7 @@ __all__ = ["import_definition", "RegisterType", "GenericRegisterType"]
 # Functions
 
 
-def import_definition(cls, filenames: List[str], dummy):
+def import_definition(cls, filenames, dummy):
     """
 
     :param filenames:
@@ -50,7 +50,7 @@ def import_definition(cls, filenames: List[str], dummy):
 
     LOG.debug("Start")
     regts = {}
-    regts_duplicated: Dict[Tuple[int, bool, bool, bool], str] = {}
+    regts_duplicated = {}
 
     for filename in filenames:
         regt_data = read_yaml(filename, SCHEMA)

--- a/src/microprobe/target/isa/schemas/__init__.py
+++ b/src/microprobe/target/isa/schemas/__init__.py
@@ -16,8 +16,10 @@
 <your module documentation here>.
 """
 
+from typing import List
+
 # Constants
-__all__ = []
+__all__: List[str] = []
 
 # Functions
 

--- a/src/microprobe/target/uarch/__init__.py
+++ b/src/microprobe/target/uarch/__init__.py
@@ -296,7 +296,7 @@ class GenericMicroarchitecture(Microarchitecture):
         self._name = name
         self._descr = descr
         self._elements = elements
-        self._target = None
+        self._target: Target | None = None
         self._instruction_property_defs = instruction_properties_defs
 
     @property

--- a/src/microprobe/target/uarch/cache.py
+++ b/src/microprobe/target/uarch/cache.py
@@ -349,7 +349,7 @@ class SetAssociativeCache(Cache):
 class CacheHierarchy:
     """Class to represent a cache hierarchy."""
 
-    def __init__(self, caches: List[Cache]):
+    def __init__(self, caches):
         """
 
         :param caches:

--- a/src/microprobe/target/uarch/schemas/__init__.py
+++ b/src/microprobe/target/uarch/schemas/__init__.py
@@ -16,8 +16,10 @@
 <your module documentation here>.
 """
 
+from typing import List
+
 # Constants
-__all__ = []
+__all__: List[str] = []
 
 # Functions
 

--- a/src/microprobe/utils/__init__.py
+++ b/src/microprobe/utils/__init__.py
@@ -15,8 +15,10 @@
 
 """
 
+from typing import List
+
 # Constants
-__all__ = []
+__all__: List[str] = []
 
 # Functions
 

--- a/src/microprobe/utils/bin.py
+++ b/src/microprobe/utils/bin.py
@@ -36,6 +36,7 @@ import itertools
 import math
 import string
 import re
+from typing import List
 
 # Third party modules
 import cachetools
@@ -74,7 +75,7 @@ _CODE_CACHE_SAVED = False
 _CODE_CACHE_SIZE = 16*1024
 _CODE_CACHE_STATS = {'hit': 0, 'access': 0}
 _DATA_CACHE = RejectingDict()
-_DATA_CACHE_LENGTHS = []
+_DATA_CACHE_LENGTHS: List[str] = []
 _DATA_CACHE_ENABLED = False
 
 __all__ = ["interpret_bin",

--- a/src/microprobe/utils/info.py
+++ b/src/microprobe/utils/info.py
@@ -17,13 +17,14 @@
 
 # Futures
 from __future__ import absolute_import
+from typing import List
 
 # Own modules
 from microprobe import MICROPROBE_RC
 
 __author__ = "Ramon Bertran"
 __copyright__ = "Copyright 2011-2021 IBM Corporation"
-__credits__ = []
+__credits__: List[str] = []
 __license__ = "Apaceh Version 2.0"
 __version__ = "0.5"
 __maintainer__ = "Ramon Bertran"

--- a/src/microprobe/utils/misc.py
+++ b/src/microprobe/utils/misc.py
@@ -34,12 +34,7 @@ import timeit
 from microprobe.exceptions import MicroprobeDuplicatedValueError
 from microprobe.utils.logger import get_logger
 
-try:
-    from collections import OrderedDict
-except ImportError:
-    # python 2.6 or earlier, use ordereddict back-port
-    # pylint: disable-msg=F0401
-    from ordereddict import OrderedDict
+from collections import OrderedDict
 
 
 # Constants

--- a/src/microprobe/utils/mpt.py
+++ b/src/microprobe/utils/mpt.py
@@ -455,7 +455,7 @@ class MicroprobeTestDefinition(six.with_metaclass(abc.ABCMeta, object)):
 
 class MicroprobeTestDefinitionDefault(MicroprobeTestDefinition):
     """Class to represent a Microprobe Test configuration (default impl.)"""
-    version = 0
+    version = 0.
 
     def __init__(self):
 


### PR DESCRIPTION
This adds mypy static type checking to the CI (and some related changes required to make it pass).

Mypy does not lint untyped functions, so I removed some type annotations for particularly hard to annotate cases.

Currently we only check the `/target` and `/code` folders.