### PR TITLE
Add testsuite runtime type checking

### DIFF
--- a/requirements_devel.txt
+++ b/requirements_devel.txt
@@ -49,3 +49,4 @@ yapf
 isort
 twine
 mypy
+typeguard

--- a/src/microprobe/code/address.py
+++ b/src/microprobe/code/address.py
@@ -20,7 +20,7 @@ from __future__ import absolute_import, annotations, print_function
 
 # Built in modules
 import hashlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 # Third party modules
 import six
@@ -29,6 +29,7 @@ import six
 from microprobe.code.var import Variable
 from microprobe.exceptions import MicroprobeCodeGenerationError
 from microprobe.utils.logger import get_logger
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Type hinting
 if TYPE_CHECKING:
@@ -42,6 +43,7 @@ __all__ = ["MemoryValue", "Address", "InstructionAddress"]
 
 
 # Classes
+@typeguard_testsuite
 class Address:
     """Class to represent an address."""
 
@@ -72,7 +74,7 @@ class Address:
         self._hash = None
 
     @property
-    def base_address(self) -> Variable | str | None:
+    def base_address(self) -> Union[Variable, str, None]:
         """Base address of the address (:class:`~.str`)"""
         return self._base_address
 
@@ -329,6 +331,7 @@ class Address:
             raise NotImplementedError
 
 
+@typeguard_testsuite
 class InstructionAddress(Address):
     """Class to represent an instruction address."""
 
@@ -417,12 +420,13 @@ class InstructionAddress(Address):
         return super(InstructionAddress, self).__sub__(other)
 
 
+@typeguard_testsuite
 class MemoryValue(object):
     """Class to represent a value in memory."""
 
     _cmp_attributes = ['address', 'value', 'length']
 
-    def __init__(self, address: Address, value: int, length: int):
+    def __init__(self, address: Address, value: int | float, length: int):
         """
 
         :param address:

--- a/src/microprobe/code/bbl.py
+++ b/src/microprobe/code/bbl.py
@@ -30,6 +30,7 @@ from microprobe.exceptions import MicroprobeCodeGenerationError, \
     MicroprobeValueError
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import Progress
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Type hinting
 if TYPE_CHECKING:
@@ -41,6 +42,7 @@ __all__ = ["Bbl", "replicate_bbls"]
 
 
 # Functions
+@typeguard_testsuite
 def replicate_bbls(bbl_list: List[Bbl], displacement: int | None = None):
     """Returns a copy the given basic block list at the specified displacement.
 
@@ -60,6 +62,7 @@ def replicate_bbls(bbl_list: List[Bbl], displacement: int | None = None):
 
 
 # Classes
+@typeguard_testsuite
 class Bbl:
     """Class to represent a basic block."""
 

--- a/src/microprobe/code/benchmark.py
+++ b/src/microprobe/code/benchmark.py
@@ -26,6 +26,7 @@ from microprobe.code.address import Address
 from microprobe.exceptions import MicroprobeCodeGenerationError
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import OrderedDict
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Type hinting
 if TYPE_CHECKING:
@@ -41,6 +42,7 @@ __all__ = [
 
 
 # Functions
+@typeguard_testsuite
 def benchmark_factory(threads: int = 1):
     if threads == 1:
         return Benchmark()
@@ -49,6 +51,7 @@ def benchmark_factory(threads: int = 1):
 
 
 # Classes
+@typeguard_testsuite
 class BuildingBlock(object):
     """Class to represent a benchmark building block.
 
@@ -143,6 +146,7 @@ class BuildingBlock(object):
         return self._requirements
 
 
+@typeguard_testsuite
 class Benchmark(BuildingBlock):
     """Class to represent a benchmark (highest level building block)."""
 
@@ -453,6 +457,7 @@ class Benchmark(BuildingBlock):
                 (idx, self._num_threads + 1))
 
 
+@typeguard_testsuite
 class MultiThreadedBenchmark(Benchmark):
     """ """
 

--- a/src/microprobe/code/cfg.py
+++ b/src/microprobe/code/cfg.py
@@ -22,6 +22,7 @@ from typing import TYPE_CHECKING, List, Tuple
 # Own modules
 from microprobe.code.bbl import Bbl
 from microprobe.utils.logger import get_logger
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Type hinting
 if TYPE_CHECKING:
@@ -36,6 +37,7 @@ __all__ = ["Cfg"]
 # Classes
 
 
+@typeguard_testsuite
 class Cfg:
     """Class to represent the control flow graph of a building block."""
 

--- a/src/microprobe/code/context.py
+++ b/src/microprobe/code/context.py
@@ -426,7 +426,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
         """
         return value in list([
             elem for elem in self._value_registers.keys()
-            if type(elem) == type(value)
+            if type(elem) is type(value)
         ])
 
     def registers_get_value(self, value: int | float | Address | str):

--- a/src/microprobe/code/context.py
+++ b/src/microprobe/code/context.py
@@ -28,6 +28,7 @@ import six
 from microprobe.code.address import Address, InstructionAddress
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import RejectingDict, smart_copy_dict
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Type hinting
 if TYPE_CHECKING:
@@ -43,6 +44,7 @@ __all__ = ["Context"]
 
 
 # Classes
+@typeguard_testsuite
 class Context(object):  # pylint: disable=too-many-public-methods
     """Class to represent the execution context (e.g. register values, etc ...
     on each benchmark building block)
@@ -205,7 +207,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
 
         """
 
-        possible_regs: List[Tuple[Register, Address]] = []
+        possible_regs: List[Tuple["Register", Address]] = []
 
         for reg, value in self._register_values.items():
 
@@ -457,7 +459,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
         """Address starting the data segment (::class:`~.int`)"""
         return self._data_segment
 
-    def set_data_segment(self, value: int):
+    def set_data_segment(self, value: int | None):
         """Sets the data segment start address.
 
         :param value: Start address.
@@ -485,7 +487,7 @@ class Context(object):  # pylint: disable=too-many-public-methods
         """Address starting the code segment (::class:`~.int`)"""
         return self._code_segment
 
-    def set_code_segment(self, value: int):
+    def set_code_segment(self, value: int | None):
         """Sets the code segment start address.
 
         :param value: Start address.

--- a/src/microprobe/code/ins.py
+++ b/src/microprobe/code/ins.py
@@ -39,6 +39,7 @@ from microprobe.utils.asm import interpret_asm
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import OrderedDict, \
     Pickable, RejectingDict, RejectingOrderedDict
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Type hinting
 if TYPE_CHECKING:
@@ -65,6 +66,7 @@ _LABEL_COUNTER = 0
 
 
 # Functions
+@typeguard_testsuite
 def instruction_to_definition(instr: Instruction):
     """
     Return the definition of an instruction.
@@ -93,6 +95,7 @@ def instruction_to_definition(instr: Instruction):
         asm, instr.decorators, comments)
 
 
+@typeguard_testsuite
 def instruction_from_definition(definition: MicroprobeInstructionDefinition,
                                 fix_relative: bool = True):
     """
@@ -113,6 +116,7 @@ def instruction_from_definition(definition: MicroprobeInstructionDefinition,
     return ninstr
 
 
+@typeguard_testsuite
 def instruction_set_def_properties(instr,
                                    definition,
                                    building_block=None,
@@ -330,6 +334,7 @@ def instruction_set_def_properties(instr,
     #        building_block.add_warning(str(warning_check))
 
 
+@typeguard_testsuite
 def instructions_from_asm(asm, target, labels=None, fix_relative=True):
     """
 
@@ -348,6 +353,7 @@ def instructions_from_asm(asm, target, labels=None, fix_relative=True):
     return instrs
 
 
+@typeguard_testsuite
 def instruction_factory(ins_type: InstructionType):
     """Return a instruction of the given instruction type.
 
@@ -362,6 +368,7 @@ def instruction_factory(ins_type: InstructionType):
 
 
 # Classes
+@typeguard_testsuite
 class InstructionOperandValue(Pickable):
     """Class to represent an instruction operand value"""
 
@@ -484,7 +491,7 @@ class InstructionOperandValue(Pickable):
                                             self.value)
 
     def register_operand_callbacks(self, set_function,
-                                   unset_function: Callable[[], None]):
+                                   unset_function: Callable[[], None] | None):
         """
 
         :param set_function:
@@ -498,6 +505,7 @@ class InstructionOperandValue(Pickable):
         self._unset_function = unset_function
 
 
+@typeguard_testsuite
 class InstructionMemoryOperandValue(Pickable):
     """Class to represent an instruction operand value"""
 
@@ -1579,6 +1587,7 @@ class InstructionMemoryOperandValue(Pickable):
                                               str(self.type), self.address)
 
 
+@typeguard_testsuite
 class Instruction(Pickable):
     """Class to represent an instruction"""
 
@@ -2075,6 +2084,7 @@ class Instruction(Pickable):
         return state
 
 
+@typeguard_testsuite
 def create_dependency_between_ins(output_ins: Instruction,
                                   input_ins: Instruction, context: Context):
     """
@@ -2150,10 +2160,11 @@ def create_dependency_between_ins(output_ins: Instruction,
     return dependency_set
 
 
+@typeguard_testsuite
 class MicroprobeInstructionDefinition(object):
 
     def __init__(self, instruction_type: InstructionType, operands, label,
-                 address: Address, asm, decorators, comments):
+                 address: Address | None, asm, decorators, comments):
 
         self._type = instruction_type
         self._operands = operands

--- a/src/microprobe/code/var.py
+++ b/src/microprobe/code/var.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Dict, List
 # Own modules
 from microprobe.exceptions import MicroprobeCodeGenerationError
 from microprobe.utils.logger import get_logger
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Type hinting
 if TYPE_CHECKING:
@@ -93,6 +94,7 @@ VAR_TYPE_LEN_DICT["uint_fast64_t"] = 8
 
 
 # Classes
+@typeguard_testsuite
 class Variable(abc.ABC):
     """ """
 
@@ -239,6 +241,7 @@ class Variable(abc.ABC):
         return self._hash
 
 
+@typeguard_testsuite
 class VariableSingle(Variable):
     """ """
 
@@ -326,6 +329,7 @@ class VariableSingle(Variable):
         return "(%s) %s" % (self.type, self.name)
 
 
+@typeguard_testsuite
 class VariableArray(Variable):
     """ """
 

--- a/src/microprobe/code/wrapper.py
+++ b/src/microprobe/code/wrapper.py
@@ -25,6 +25,7 @@ from typing import TYPE_CHECKING, Callable, List
 from microprobe.code.context import Context
 from microprobe.exceptions import MicroprobeCodeGenerationError
 from microprobe.utils.logger import get_logger
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Type hinting
 if TYPE_CHECKING:
@@ -42,6 +43,7 @@ __all__ = ["Wrapper"]
 
 
 # Classes
+@typeguard_testsuite
 class Wrapper(abc.ABC):
     """
     Abstract class to represent a language wrapper.

--- a/src/microprobe/passes/memory/__init__.py
+++ b/src/microprobe/passes/memory/__init__.py
@@ -32,7 +32,7 @@ import microprobe.code.var
 import microprobe.passes
 import microprobe.utils.distrib
 from microprobe.code.address import Address, InstructionAddress
-from microprobe.exceptions import MicroprobeCodeGenerationError,\
+from microprobe.exceptions import MicroprobeCodeGenerationError, \
         MicroprobeValueError
 from microprobe.target.isa.operand import OperandConst, \
     OperandConstReg, OperandDescriptor, OperandReg
@@ -2086,8 +2086,8 @@ class GenericMemoryStreamsPass(microprobe.passes.Pass):
                 ):
 
                     mcomp = self._func()
-                    var, reg_basel, reg_base_vall, reg_idxl, reg_idx_vall,\
-                        calc_instrsl, last_instr, count, module, reduced,\
+                    var, reg_basel, reg_base_vall, reg_idxl, reg_idx_vall, \
+                        calc_instrsl, last_instr, count, module, reduced, \
                         max_value, sind = descriptors[mcomp]
 
                     reg_base = reg_basel[sind]
@@ -2257,7 +2257,7 @@ class GenericMemoryStreamsPass(microprobe.passes.Pass):
                     #    reg_idx_val, calc_instrs
                     # )
 
-                    # reg_base_val_new, reg_idx_val_new,\
+                    # reg_base_val_new, reg_idx_val_new, \
                     #    tinstrs, new_instrs = values
 
                     for key, value in descriptors.items():
@@ -2487,8 +2487,8 @@ class GenericMemoryStreamsPass(microprobe.passes.Pass):
         emptycontext = target.wrapper.context()
 
         for sid, size, ratio, stride, streams, shuffle, loc in self._model:
-            var, reg_basel, reg_base_vall, reg_idxl, reg_idx_vall,\
-                calc_instrs, last_instr, count, module, reduced,\
+            var, reg_basel, reg_base_vall, reg_idxl, reg_idx_vall, \
+                calc_instrs, last_instr, count, module, reduced, \
                 max_value, sind = descriptors[sid]
 
             if max_value == 0:

--- a/src/microprobe/target/env/__init__.py
+++ b/src/microprobe/target/env/__init__.py
@@ -36,6 +36,7 @@ from microprobe.property import Property, PropertyHolder
 from microprobe.utils.imp import find_subclasses
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import findfiles
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Local modules
 
@@ -44,6 +45,7 @@ if TYPE_CHECKING:
     from microprobe.target.isa import ISA
     from microprobe.code.ins import Instruction
     from microprobe.target import Target
+    from microprobe.target import Definition
     from microprobe.target.isa.register import Register
 
 # Constants
@@ -58,6 +60,7 @@ __all__ = [
 
 
 # Functions
+@typeguard_testsuite
 def import_env_definition(module,
                           isa: ISA,
                           definition_name: str | None = None):
@@ -99,6 +102,7 @@ def import_env_definition(module,
     return environment
 
 
+@typeguard_testsuite
 def find_env_definitions(paths: List[str] | None = None):
 
     LOG.debug("Start find environment definitions")
@@ -117,7 +121,7 @@ def find_env_definitions(paths: List[str] | None = None):
     paths = paths + MICROPROBE_RC["environment_paths"] \
         + MICROPROBE_RC["default_paths"]
 
-    results: List[Definition] = []
+    results: List["Definition"] = []
     files = findfiles(paths, "env/.*.py$", full=True)
 
     if len(files) > 0:
@@ -151,6 +155,7 @@ def find_env_definitions(paths: List[str] | None = None):
 
 
 # Classes
+@typeguard_testsuite
 class Environment(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
     """ """
 
@@ -281,6 +286,7 @@ class Environment(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
         raise NotImplementedError
 
 
+@typeguard_testsuite
 class GenericEnvironment(Environment):
     """ """
 

--- a/src/microprobe/target/isa/__init__.py
+++ b/src/microprobe/target/isa/__init__.py
@@ -652,7 +652,8 @@ class GenericISA(ISA):
     """Class to represent a generic Instruction Set Architecture (ISA)."""
 
     def __init__(self, name: str, descr: str, path: str,
-                 ins: Dict[str, "InstructionType"], regs: Dict[str, "Register"],
+                 ins: Dict[str, "InstructionType"],
+                 regs: Dict[str, "Register"],
                  comparators, generators):
         """
 

--- a/src/microprobe/target/isa/__init__.py
+++ b/src/microprobe/target/isa/__init__.py
@@ -46,6 +46,7 @@ from microprobe.utils.imp import get_object_from_module, \
     import_cls_definition, import_definition, import_operand_definition
 from microprobe.utils.logger import DEBUG, get_logger
 from microprobe.utils.misc import dict2OrderedDict, findfiles
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 from microprobe.utils.yaml import read_yaml
 
 # Local modules
@@ -55,7 +56,7 @@ if TYPE_CHECKING:
     from microprobe.target import Definition, Target
     from microprobe.target.isa.register import Register
     from microprobe.code.var import Variable
-    from microprobe.code.ins import Instruction, InstructionType
+    from microprobe.code.ins import InstructionType
 
 # Constants
 SCHEMA = os.path.join(os.path.dirname(os.path.abspath(__file__)), "schemas",
@@ -69,6 +70,7 @@ __all__ = [
 
 
 # Functions
+@typeguard_testsuite
 def _read_isa_extensions(isadefs: List[Dict[str, str]], path: str):
     """
 
@@ -91,6 +93,7 @@ def _read_isa_extensions(isadefs: List[Dict[str, str]], path: str):
         _read_isa_extensions(isadefs, isadefval)
 
 
+@typeguard_testsuite
 def _read_yaml_definition(isadefs: List[Dict[str, str]], path: str):
     """
 
@@ -169,6 +172,7 @@ def _read_yaml_definition(isadefs: List[Dict[str, str]], path: str):
     return complete_isadef
 
 
+@typeguard_testsuite
 def import_isa_definition(path: str):
     """Imports a ISA definition given a path
 
@@ -340,6 +344,7 @@ def find_isa_definitions(paths: List[str] | None = None):
 
 
 # Classes
+@typeguard_testsuite
 class ISA(abc.ABC):
     """Abstract class to represent an Instruction Set Architecture (ISA).
 
@@ -372,7 +377,7 @@ class ISA(abc.ABC):
 
     @property
     @abc.abstractmethod
-    def instructions(self) -> Dict[str, InstructionType]:
+    def instructions(self) -> Dict[str, "InstructionType"]:
         """ISA instructions (:class:`~.dict` mapping strings to
         :class:`~.InstructionType`)."""
         raise NotImplementedError
@@ -642,11 +647,12 @@ class ISA(abc.ABC):
         raise NotImplementedError
 
 
+@typeguard_testsuite
 class GenericISA(ISA):
     """Class to represent a generic Instruction Set Architecture (ISA)."""
 
     def __init__(self, name: str, descr: str, path: str,
-                 ins: Dict[str, InstructionType], regs: Dict[str, Register],
+                 ins: Dict[str, "InstructionType"], regs: Dict[str, "Register"],
                  comparators, generators):
         """
 

--- a/src/microprobe/target/isa/comparator.py
+++ b/src/microprobe/target/isa/comparator.py
@@ -27,6 +27,7 @@ import abc
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.imp import find_subclasses
 from microprobe.utils.logger import get_logger
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Constants
 LOG = get_logger(__name__)
@@ -34,6 +35,7 @@ __all__ = ["import_classes_from", "Comparator"]
 
 
 # Functions
+@typeguard_testsuite
 def import_classes_from(modules):
     """
 
@@ -65,6 +67,7 @@ def import_classes_from(modules):
 
 
 # Classes
+@typeguard_testsuite
 class Comparator(object, metaclass=abc.ABCMeta):
     """Abstract class to perform comparisons. :class:`~.Comparator`
     objects are in charge of performing comparisons between values

--- a/src/microprobe/target/isa/dat.py
+++ b/src/microprobe/target/isa/dat.py
@@ -29,6 +29,7 @@ from microprobe.exceptions import MicroprobeAddressTranslationError, \
     MicroprobeDuplicatedValueError
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import RejectingDict
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Constants
 
@@ -39,6 +40,7 @@ __all__ = ["DynamicAddressTranslation", "GenericDynamicAddressTranslation"]
 
 
 # Classes
+@typeguard_testsuite
 class DynamicAddressTranslation(abc.ABC):
     """ """
 
@@ -89,6 +91,7 @@ class DynamicAddressTranslation(abc.ABC):
         raise NotImplementedError
 
 
+@typeguard_testsuite
 class GenericDynamicAddressTranslation(DynamicAddressTranslation):
     """ """
 
@@ -179,6 +182,7 @@ class GenericDynamicAddressTranslation(DynamicAddressTranslation):
             self._control[key] = value['value']
 
 
+@typeguard_testsuite
 class DATmap:
     """ """
 

--- a/src/microprobe/target/isa/generator.py
+++ b/src/microprobe/target/isa/generator.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, List
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.imp import find_subclasses
 from microprobe.utils.logger import get_logger
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Type hinting
 if TYPE_CHECKING:
@@ -40,6 +41,7 @@ __all__ = ["import_classes_from", "Generator"]
 
 
 # Functions
+@typeguard_testsuite
 def import_classes_from(modules: List[str]):
     """
 
@@ -72,6 +74,7 @@ def import_classes_from(modules: List[str]):
 
 
 # Classes
+@typeguard_testsuite
 class Generator(abc.ABC):
     """ """
 

--- a/src/microprobe/target/isa/instruction.py
+++ b/src/microprobe/target/isa/instruction.py
@@ -41,6 +41,7 @@ from microprobe.target.isa.instruction_field import GenericInstructionField
 from microprobe.target.isa.instruction_format import GenericInstructionFormat
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import OrderedDict, getnextf
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 from microprobe.utils.yaml import read_yaml
 
 # Type hinting
@@ -59,6 +60,7 @@ __all__ = [
 
 
 # Functions
+@typeguard_testsuite
 def import_definition(cls, filenames, args):
     """
 
@@ -142,6 +144,7 @@ def import_definition(cls, filenames, args):
     return instructions
 
 
+@typeguard_testsuite
 def instruction_type_from_bin(binstr, target):
     """
 
@@ -172,6 +175,7 @@ def instruction_type_from_bin(binstr, target):
     return instr_type
 
 
+@typeguard_testsuite
 def _translate_checks(name, filename, cls, checks, dummy_operands):
     """
 
@@ -213,6 +217,7 @@ def _translate_checks(name, filename, cls, checks, dummy_operands):
     return dict(translated_checks)
 
 
+@typeguard_testsuite
 def _translate_moperands(name, filename, operands, ioperands, moperands,
                          defined_memory_operands, iformat):
     """
@@ -365,6 +370,7 @@ def _translate_moperands(name, filename, operands, ioperands, moperands,
     return roperands
 
 
+@typeguard_testsuite
 def _translate_ioperands(name, filename, ioperands, defined_operands):
     """
 
@@ -424,6 +430,7 @@ def _translate_ioperands(name, filename, ioperands, defined_operands):
     return roperands
 
 
+@typeguard_testsuite
 def _merge_operands(name, filename, loperands, iformat, defined_operands):
     """
 
@@ -513,6 +520,7 @@ def _merge_operands(name, filename, loperands, iformat, defined_operands):
 
 
 # Generic Instruction checks
+@typeguard_testsuite
 def _check_reg_value(instruction, register_name, value, condition):
     """
 
@@ -662,6 +670,7 @@ def _check_reg_value(instruction, register_name, value, condition):
                                               fixing_function_true)
 
 
+@typeguard_testsuite
 def _check_reg_bit_value(instruction, register_name, bit, value, condition):
     """
 
@@ -732,6 +741,7 @@ def _check_reg_bit_value(instruction, register_name, bit, value, condition):
                                           fixing_function)
 
 
+@typeguard_testsuite
 def _check_operands(instruction, operand1_name, operand2_name, check_type,
                     condition):
     """
@@ -990,6 +1000,7 @@ def _check_operands(instruction, operand1_name, operand2_name, check_type,
                                   check_type)
 
 
+@typeguard_testsuite
 def _check_memops_overlap(instruction, overlap_type, condition):
     """
 
@@ -1278,6 +1289,7 @@ def _check_memops_overlap(instruction, overlap_type, condition):
         raise NotImplementedError
 
 
+@typeguard_testsuite
 def _check_alignment(instruction, operand_idx, alignment):
     """
 
@@ -1303,6 +1315,7 @@ for _key, _value in dict(getmembers(sys.modules[__name__],
 
 
 # Classes
+@typeguard_testsuite
 class InstructionType(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
     """Abstract class to represent a machine instruction type."""
 
@@ -1421,6 +1434,7 @@ class InstructionType(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
         raise NotImplementedError
 
 
+@typeguard_testsuite
 class GenericInstructionType(InstructionType):
     """Instruction generic class implementation
 

--- a/src/microprobe/target/isa/instruction_field.py
+++ b/src/microprobe/target/isa/instruction_field.py
@@ -45,7 +45,9 @@ __all__ = ["import_definition", "InstructionField", "GenericInstructionField"]
 
 # Functions
 @typeguard_testsuite
-def import_definition(cls, filenames: List[str], operands: Dict[str, "Operand"]):
+def import_definition(cls,
+                      filenames: List[str],
+                      operands: Dict[str, "Operand"]):
     """
 
     :param filenames:

--- a/src/microprobe/target/isa/instruction_field.py
+++ b/src/microprobe/target/isa/instruction_field.py
@@ -28,6 +28,7 @@ from typing import TYPE_CHECKING, Dict, List, Tuple, cast
 # Own modules
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.logger import get_logger
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 from microprobe.utils.yaml import read_yaml
 
 # Type hinting
@@ -43,7 +44,8 @@ __all__ = ["import_definition", "InstructionField", "GenericInstructionField"]
 
 
 # Functions
-def import_definition(cls, filenames: List[str], operands: Dict[str, Operand]):
+@typeguard_testsuite
+def import_definition(cls, filenames: List[str], operands: Dict[str, "Operand"]):
     """
 
     :param filenames:
@@ -103,6 +105,7 @@ def import_definition(cls, filenames: List[str], operands: Dict[str, Operand]):
 
 
 # Classes
+@typeguard_testsuite
 class InstructionField(abc.ABC):
     """Abstract class to represent an instruction field"""
 
@@ -145,6 +148,7 @@ class InstructionField(abc.ABC):
         raise NotImplementedError
 
 
+@typeguard_testsuite
 class GenericInstructionField(InstructionField):
     """Instruction field generic class.
 

--- a/src/microprobe/target/isa/instruction_format.py
+++ b/src/microprobe/target/isa/instruction_format.py
@@ -29,6 +29,7 @@ from typing import TYPE_CHECKING, List, Tuple
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError, \
     MicroprobeLookupError
 from microprobe.utils.logger import get_logger
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 from microprobe.utils.yaml import read_yaml
 
 # Type hinting
@@ -45,6 +46,7 @@ __all__ = [
 
 
 # Functions
+@typeguard_testsuite
 def import_definition(cls, filenames, ifields):
     """
 
@@ -110,6 +112,7 @@ def import_definition(cls, filenames, ifields):
 
 
 # Classes
+@typeguard_testsuite
 class InstructionFormat(abc.ABC):
     """Abstract class to represent an instruction format"""
 
@@ -243,6 +246,7 @@ class InstructionFormat(abc.ABC):
         return rstr
 
 
+@typeguard_testsuite
 class GenericInstructionFormat(InstructionFormat):
     """Instruction format generic class."""
 

--- a/src/microprobe/target/isa/operand.py
+++ b/src/microprobe/target/isa/operand.py
@@ -36,6 +36,7 @@ from microprobe.exceptions import MicroprobeArchitectureDefinitionError, \
 from microprobe.target.isa.register import Register
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import OrderedDict, natural_sort
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 from microprobe.utils.yaml import read_yaml
 
 # Constants
@@ -52,6 +53,7 @@ __all__ = [
 
 
 # Functions
+@typeguard_testsuite
 def import_definition(filenames, inherits, registers):
     """
 
@@ -255,6 +257,7 @@ def import_definition(filenames, inherits, registers):
     return operands
 
 
+@typeguard_testsuite
 def _format_integer(operand, value):
 
     if MICROPROBE_RC['hex_all']:
@@ -276,6 +279,7 @@ def _format_integer(operand, value):
 
 
 # Classes
+@typeguard_testsuite
 class OperandDescriptor:
     """Class to represent an operand descriptor.
 
@@ -328,6 +332,7 @@ class OperandDescriptor:
                                    self._is_input, self._is_output)
 
 
+@typeguard_testsuite
 class MemoryOperandDescriptor:
     """Class to represent a memory operand descriptor.
 
@@ -419,6 +424,7 @@ class MemoryOperandDescriptor:
         return rstr
 
 
+@typeguard_testsuite
 class MemoryOperand:
     """This represents a machine instruction memory operand. It contains
     the operands, the formula, the
@@ -520,6 +526,7 @@ class MemoryOperand:
         return rstr
 
 
+@typeguard_testsuite
 class Operand(abc.ABC):
     """This represents a machine instruction operand"""
 
@@ -754,6 +761,7 @@ class Operand(abc.ABC):
         return True
 
 
+@typeguard_testsuite
 class OperandReg(Operand):
     """Class to represent a register operand.
 
@@ -870,6 +878,7 @@ class OperandReg(Operand):
         self._const = len(values) == 1
 
 
+@typeguard_testsuite
 class OperandImmRange(Operand):
     """Class to represent a immediate range operand.
 
@@ -1037,6 +1046,7 @@ class OperandImmRange(Operand):
         raise NotImplementedError
 
 
+@typeguard_testsuite
 class OperandValueSet(Operand):
     """Class to represent a value set operand.
 
@@ -1136,6 +1146,7 @@ class OperandValueSet(Operand):
         self._const = len(values) == 1
 
 
+@typeguard_testsuite
 class OperandConst(Operand):
     """Class to represent a constant operand.
 
@@ -1226,6 +1237,7 @@ class OperandConst(Operand):
         self._value = values[0]
 
 
+@typeguard_testsuite
 class OperandConstReg(Operand):
     """Class to represent a constant register operand.
 
@@ -1328,6 +1340,7 @@ class OperandConstReg(Operand):
         self._reg = values[0]
 
 
+@typeguard_testsuite
 class InstructionAddressRelativeOperand(Operand):
     """Class to represent a relative instruction address operand.
 

--- a/src/microprobe/target/isa/register.py
+++ b/src/microprobe/target/isa/register.py
@@ -31,6 +31,7 @@ from six.moves import range
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import Pickable
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 from microprobe.utils.yaml import read_yaml
 
 # Type hinting
@@ -46,6 +47,7 @@ __all__ = ["import_definition", "Register", "GenericRegister"]
 
 
 # Functions
+@typeguard_testsuite
 def import_definition(cls, filenames: List[str], regtypes):
     """
 
@@ -107,6 +109,7 @@ def import_definition(cls, filenames: List[str], regtypes):
 
 
 # Classes
+@typeguard_testsuite
 class Register(abc.ABC):
     """Abstract class to represent an architecture register."""
 
@@ -157,6 +160,7 @@ class Register(abc.ABC):
         raise NotImplementedError
 
 
+@typeguard_testsuite
 class GenericRegister(Register, Pickable):
     """A Generic architected register"""
 

--- a/src/microprobe/target/isa/register_type.py
+++ b/src/microprobe/target/isa/register_type.py
@@ -29,6 +29,7 @@ from typing import Dict, List, Tuple
 # Own modules
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.logger import get_logger
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 from microprobe.utils.yaml import read_yaml
 
 # Constants
@@ -40,6 +41,7 @@ __all__ = ["import_definition", "RegisterType", "GenericRegisterType"]
 # Functions
 
 
+@typeguard_testsuite
 def import_definition(cls, filenames, dummy):
     """
 
@@ -89,6 +91,7 @@ def import_definition(cls, filenames, dummy):
 
 
 # Classes
+@typeguard_testsuite
 class RegisterType(abc.ABC):
     """Abstract base class to represent a Register Type"""
 
@@ -144,6 +147,7 @@ class RegisterType(abc.ABC):
         raise NotImplementedError
 
 
+@typeguard_testsuite
 class GenericRegisterType(RegisterType):
     """A class to represent a register type. Each register type is identified
     by its *type*, its *size* in bits and also its *semantic* properites (e.g.

--- a/src/microprobe/target/uarch/__init__.py
+++ b/src/microprobe/target/uarch/__init__.py
@@ -35,6 +35,7 @@ from microprobe.target.uarch.cache import cache_hierarchy_from_elements
 from microprobe.utils.imp import get_object_from_module, import_definition
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import findfiles
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 from microprobe.utils.yaml import read_yaml
 import six
 
@@ -58,6 +59,7 @@ __all__ = [
 
 
 # Functions
+@typeguard_testsuite
 def _read_uarch_extensions(uarchdefs, path: str):
     """ """
 
@@ -76,6 +78,7 @@ def _read_uarch_extensions(uarchdefs, path: str):
         _read_uarch_extensions(uarchdefs, uarchdefval)
 
 
+@typeguard_testsuite
 def _read_yaml_definition(uarchdefs, path: str):
     """
 
@@ -145,6 +148,7 @@ def _read_yaml_definition(uarchdefs, path: str):
     return complete_uarchdef
 
 
+@typeguard_testsuite
 def import_microarchitecture_definition(path: str):
     """Imports a Microarchitecture definition given a path
 
@@ -186,6 +190,7 @@ def import_microarchitecture_definition(path: str):
     return uarch
 
 
+@typeguard_testsuite
 def find_microarchitecture_definitions(paths: List[str] | None = None):
 
     if paths is None:
@@ -225,6 +230,7 @@ def find_microarchitecture_definitions(paths: List[str] | None = None):
 
 
 # Classes
+@typeguard_testsuite
 class Microarchitecture(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
     """ """
 
@@ -279,6 +285,7 @@ class Microarchitecture(six.with_metaclass(abc.ABCMeta, PropertyHolder)):
         raise NotImplementedError
 
 
+@typeguard_testsuite
 class GenericMicroarchitecture(Microarchitecture):
     """ """
 
@@ -353,6 +360,7 @@ class GenericMicroarchitecture(Microarchitecture):
                                    self.description)
 
 
+@typeguard_testsuite
 class GenericCPUMicroarchitecture(GenericMicroarchitecture):
     """Generic CPU Microarchitecture
 

--- a/src/microprobe/target/uarch/cache.py
+++ b/src/microprobe/target/uarch/cache.py
@@ -28,6 +28,7 @@ from six.moves import range
 # Own modules
 from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.utils.logger import get_logger
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 
 # Type checking
 if TYPE_CHECKING:
@@ -42,6 +43,7 @@ __all__ = [
 
 
 # Functions
+@typeguard_testsuite
 def cache_hierarchy_from_elements(elements):
     """
 
@@ -62,6 +64,7 @@ def cache_hierarchy_from_elements(elements):
     return cache_hierarchy
 
 
+@typeguard_testsuite
 def _caches_from_elements(elements):
     """
 
@@ -124,6 +127,7 @@ def _caches_from_elements(elements):
 
 
 # Classes
+@typeguard_testsuite
 class Cache:
     """Class to represent a cache."""
 
@@ -214,6 +218,7 @@ class Cache:
         return "%s('%s')" % (self.__class__.__name__, self.description)
 
 
+@typeguard_testsuite
 class SetAssociativeCache(Cache):
     """Class to represent a set-associative cache."""
 
@@ -346,6 +351,7 @@ class SetAssociativeCache(Cache):
         print_info((bit_range, offset_range, ccrange))
 
 
+@typeguard_testsuite
 class CacheHierarchy:
     """Class to represent a cache hierarchy."""
 
@@ -377,11 +383,11 @@ class CacheHierarchy:
                 "At least one cache"
                 "should be defined as first level data cache")
 
-        data_levels: Dict[MicroarchitectureElement, List[Cache]] = {}
+        data_levels: Dict["MicroarchitectureElement", List[Cache]] = {}
         for cache in first_data_levels:
             data_levels[cache.element] = [cache]
 
-        ins_levels: Dict[MicroarchitectureElement, List[Cache]] = {}
+        ins_levels: Dict["MicroarchitectureElement", List[Cache]] = {}
         for cache in first_ins_levels:
             ins_levels[cache.element] = [cache]
 

--- a/src/microprobe/target/uarch/element.py
+++ b/src/microprobe/target/uarch/element.py
@@ -32,6 +32,7 @@ from microprobe.exceptions import MicroprobeArchitectureDefinitionError
 from microprobe.property import PropertyHolder, import_properties
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import RejectingDict
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 from microprobe.utils.yaml import read_yaml
 
 # Constants
@@ -46,6 +47,7 @@ __all__ = [
 
 
 # Functions
+@typeguard_testsuite
 def import_definition(cls, filenames, element_types):
     """ """
     LOG.debug("Start importing microarchitecture elements")
@@ -196,6 +198,7 @@ def import_definition(cls, filenames, element_types):
 
 
 # Classes
+@typeguard_testsuite
 class MicroarchitectureElement(six.with_metaclass(abc.ABCMeta,
                                                   PropertyHolder)):
     """ """
@@ -277,6 +280,7 @@ class MicroarchitectureElement(six.with_metaclass(abc.ABCMeta,
         raise NotImplementedError
 
 
+@typeguard_testsuite
 class GenericMicroarchitectureElement(MicroarchitectureElement):
     """ """
 

--- a/src/microprobe/target/uarch/element_type.py
+++ b/src/microprobe/target/uarch/element_type.py
@@ -29,6 +29,7 @@ import six
 # Own modules
 from microprobe.property import PropertyHolder, import_properties
 from microprobe.utils.logger import get_logger
+from microprobe.utils.typeguard_decorator import typeguard_testsuite
 from microprobe.utils.yaml import read_yaml
 
 # Constants
@@ -43,6 +44,7 @@ __all__ = [
 
 
 # Functions
+@typeguard_testsuite
 def import_definition(cls, filenames: List[str], dummy):
     """
 
@@ -81,6 +83,7 @@ def import_definition(cls, filenames: List[str], dummy):
 
 
 # Classes
+@typeguard_testsuite
 class MicroarchitectureElementType(
         six.with_metaclass(abc.ABCMeta, PropertyHolder)):
     """Abstract class to represent a microarchitecture element type."""
@@ -113,6 +116,7 @@ class MicroarchitectureElementType(
         raise NotImplementedError
 
 
+@typeguard_testsuite
 class GenericMicroarchitectureElementType(
         six.with_metaclass(abc.ABCMeta, MicroarchitectureElementType)):
     """Class to represent a generic microarchitecture element type."""

--- a/src/microprobe/utils/cache.py
+++ b/src/microprobe/utils/cache.py
@@ -168,7 +168,7 @@ def write_cache_data(filename, data, data_reload=False):
             base_data = None
 
         if base_data is not None:
-            if type(base_data) != type(data):
+            if type(base_data) is not type(data):
                 pass
             if isinstance(base_data, dict):
                 # TODO: Control cache size of dictionary caches

--- a/src/microprobe/utils/typeguard_decorator.py
+++ b/src/microprobe/utils/typeguard_decorator.py
@@ -1,0 +1,11 @@
+import sys
+from typing import Any
+
+def typeguard_testsuite(dec: Any) -> Any:
+    """Only perform runtime type checking when running testsuite"""
+    if 'unittest' in sys.modules.keys():
+        # running in testsuite, enable runtime type checking
+        import typeguard
+        return typeguard.typechecked(dec)
+
+    return dec

--- a/src/microprobe/utils/typeguard_decorator.py
+++ b/src/microprobe/utils/typeguard_decorator.py
@@ -1,6 +1,7 @@
 import sys
 from typing import Any
 
+
 def typeguard_testsuite(dec: Any) -> Any:
     """Only perform runtime type checking when running testsuite"""
     if 'unittest' in sys.modules.keys():

--- a/targets/generic/tools/mp_mpt2bin.py
+++ b/targets/generic/tools/mp_mpt2bin.py
@@ -46,9 +46,9 @@ from microprobe.code.ins import instruction_from_definition, \
 from microprobe.exceptions import MicroprobeCodeGenerationError, \
     MicroprobeException, MicroprobeMPTFormatError, MicroprobeValueError
 from microprobe.target import import_definition
-from microprobe.utils.asm import MicroprobeAsmInstructionDefinition,\
+from microprobe.utils.asm import MicroprobeAsmInstructionDefinition, \
     interpret_asm
-from microprobe.utils.cmdline import float_type, int_type, new_file_ext,\
+from microprobe.utils.cmdline import float_type, int_type, new_file_ext, \
     print_error, print_info, print_warning, string_with_fields
 from microprobe.utils.logger import get_logger
 from microprobe.utils.misc import Progress, twocs_to_int

--- a/targets/riscv/examples/riscv_branch.py
+++ b/targets/riscv/examples/riscv_branch.py
@@ -32,7 +32,7 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 # Own modules
 from microprobe.code import Synthesizer, get_wrapper
 from microprobe.exceptions import MicroprobeException
-from microprobe.passes import initialization, instruction, register,\
+from microprobe.passes import initialization, instruction, register, \
     structure, memory, branch, address, symbol
 from microprobe.target import import_definition
 from microprobe.utils.misc import RNDINT

--- a/targets/riscv/examples/riscv_ipc.py
+++ b/targets/riscv/examples/riscv_ipc.py
@@ -32,7 +32,7 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 # Own modules
 from microprobe.code import Synthesizer, get_wrapper
 from microprobe.exceptions import MicroprobeException
-from microprobe.passes import initialization, instruction, register,\
+from microprobe.passes import initialization, instruction, register, \
     structure, memory, branch
 from microprobe.target import import_definition
 

--- a/targets/riscv/examples/riscv_ipc_c.py
+++ b/targets/riscv/examples/riscv_ipc_c.py
@@ -32,7 +32,7 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 # Own modules
 from microprobe.code import Synthesizer, get_wrapper
 from microprobe.exceptions import MicroprobeException
-from microprobe.passes import initialization, instruction, register,\
+from microprobe.passes import initialization, instruction, register, \
     structure, memory, branch
 from microprobe.target import import_definition
 

--- a/targets/riscv/examples/riscv_ipc_seq.py
+++ b/targets/riscv/examples/riscv_ipc_seq.py
@@ -34,7 +34,7 @@ from argparse import ArgumentDefaultsHelpFormatter, ArgumentParser
 # Own modules
 from microprobe.code import Synthesizer, get_wrapper
 from microprobe.exceptions import MicroprobeException
-from microprobe.passes import initialization, instruction, register,\
+from microprobe.passes import initialization, instruction, register, \
     structure, memory, branch
 from microprobe.target import import_definition
 


### PR DESCRIPTION
This PR add runtime type checking when the unittest module is loaded. When microprobe is running normally, the decorator does nothing so it doesn't impact real-world performance.

The new decorator is in `src/microprobe/utils/typeguard_decorator.py`.

I found a few minor mistypes when adding this (missing `None` cases, etc).

This should help ensure the type annotations reflect reality (or at least the codepaths exercised by the testsuite).