### PR TITLE
RISC-V: Add addi-x0 support for small immediates

### DIFF
--- a/targets/riscv/isa/riscv-common/isa.py
+++ b/targets/riscv/isa/riscv-common/isa.py
@@ -163,6 +163,11 @@ class RISCVISA(GenericISA):
                 )
                 instrs.append(addi)
 
+            elif value >= -(2**11) and value < (2**11):
+                addi = self.new_instruction("ADDI_V0")
+                addi.set_operands([value, self.registers["X0"], register])
+                instrs.append(addi)
+
             elif value >= -(2**31) and value < (2**31):
                 LOG.debug("Short path")
 


### PR DESCRIPTION
Currently immediates in the range of `-2**11` to `2**11-1` generate a lui 0 call in addition to addi. This can be optimized to use addi x0 directly without lui when setting a register.